### PR TITLE
Add dropdownClassName to dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ React.render(c, container);
           <td>whether dropdown 's with is same with select</td>
         </tr>
         <tr>
+          <td>dropdownClassName</td>
+          <td>String</td>
+          <th></th>
+          <td>additional className applied to dropdown</td>
+        </tr>
+        <tr>
           <td>dropdownStyle</td>
           <td>Object</td>
           <th>{}</th>

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -97,6 +97,7 @@ class SelectDropdown extends React.Component {
       [dropdownPrefixCls]: 1,
       [`${dropdownPrefixCls}--below`]: 1,
       [`${dropdownPrefixCls}-hidden`]: !visible,
+      [props.className]: 1,
     };
     // single and not combobox, input is inside dropdown
     return (<div key="dropdown"

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -304,6 +304,8 @@ class Select extends React.Component {
   getDropdownElement() {
     const state = this.state;
     const props = this.props;
+    let dropdownClassName = props.dropdownClassName || '';
+    dropdownClassName = `${dropdownClassName} ${props.prefixCls}-dropdown--${props.multiple ? 'multiple' : 'single'}`;
     return (<Animate
       component=""
       exclusive={true}
@@ -335,7 +337,7 @@ class Select extends React.Component {
           prefixCls={props.prefixCls}
           isMultipleOrTagsOrCombobox={isMultipleOrTagsOrCombobox(props)}
           showSearch={props.showSearch}
-          className={props.dropdownClassName}
+          className={dropdownClassName}
           dropdownMenuStyle={props.dropdownMenuStyle}
           dropdownStyle={props.dropdownStyle}>
           {props.children}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -335,6 +335,7 @@ class Select extends React.Component {
           prefixCls={props.prefixCls}
           isMultipleOrTagsOrCombobox={isMultipleOrTagsOrCombobox(props)}
           showSearch={props.showSearch}
+          className={props.dropdownClassName}
           dropdownMenuStyle={props.dropdownMenuStyle}
           dropdownStyle={props.dropdownStyle}>
           {props.children}


### PR DESCRIPTION
1. 增加 `props.dropdownClassName`。

   默认 renderToBody 之后，想要自定义某个实例的浮层样式变得很困难。

   有 `dropdownClassName` 就方便一些。

   `dropdownStyle` `dropdownMenuStyle` 的问题是 style object 写起来太累，而且不好复用。

2. 给 dropdown 加上 single 和 multiple 的样式。因为单选和复选框的浮层样式有区别，原来 render 的方式可以从父节点进行区别，现在到 body 了需要额外加上。