### PR TITLE
Fix click selected item behavior

### DIFF
--- a/src/DropdownPanel.jsx
+++ b/src/DropdownPanel.jsx
@@ -36,7 +36,7 @@ const Panel = React.createClass({
       return (<Menu
         ref="menu"
         style={props.dropdownMenuStyle}
-        onSelect={props.onMenuSelect}
+        onClick={props.onMenuSelect}
         defaultActiveFirst={true}
         activeKey={activeKey}
         multiple={props.isMultipleOrTags}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -181,10 +181,10 @@ class Select extends React.Component {
     let value = this.state.value;
     const props = this.props;
     const selectedValue = getValuePropValue(item);
-    if (value.indexOf(selectedValue) !== -1) {
-      return;
-    }
     if (isMultipleOrTags(props)) {
+      if (value.indexOf(selectedValue) !== -1) {
+        return;
+      }
       value = value.concat([selectedValue]);
     } else {
       if (value[0] === selectedValue) {


### PR DESCRIPTION
修复单选框点击当前项不消失的问题。 https://github.com/ant-design/ant-design/issues/182

用 onClick 替换了 onSelect，因为在单选框情况下 onSelect 不会始终触发。https://github.com/react-component/menu/blob/8a8dd800fbe6ff6ab66814e03298151080f656a2/src/MenuItem.jsx#L61

