### PR TITLE
Revert "Add ...props to SelectTrigger"

### DIFF
--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -198,7 +198,6 @@ const SelectTrigger = React.createClass({
                      popupVisible={visible}
                      popupClassName={classnames(popupClassName)}
                      popupStyle={props.dropdownStyle}
-                     {...props}
     >{this.props.children}</Trigger>);
   },
 });


### PR DESCRIPTION
This reverts commit 3c0044b5f542366c3019a03a07918a1bb26c5fe4.

Sorry. The position of "...props" will overwrite some property before. I find this bug when I am using ant-design. Really sorry about that. I am too confident about this PR to make such a stupid mistake. 

Please forgive me.