### PR TITLE
add white-space: nowrap

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -76,6 +76,7 @@
     .@{selectPrefixCls}-selection__rendered {
       display: block;
       overflow: hidden;
+      white-space: nowrap;
       text-overflow: ellipsis;
       padding-left: 10px;
       padding-right: 20px;


### PR DESCRIPTION
修复单选选中项内容过长时，`text-overflow: ellipsis;` 不起作用问题