### PR TITLE
clear active menu when combobox input change

### DIFF
--- a/examples/combobox.js
+++ b/examples/combobox.js
@@ -48,6 +48,7 @@ const Test = React.createClass({
           onChange={this.onChange}
           onSelect={this.onSelect}
           defaultActiveFirstOption={false}
+          notFoundContent=""
           allowClear
           placeholder="please select"
           value={this.state.value}

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -49,7 +49,7 @@ const DropdownMenu = React.createClass({
       defaultActiveFirstOption, value,
       dropdownMenuStyle, prefixCls,
       multiple, onMenuDeselect,
-      onMenuSelect } = props;
+      onMenuSelect, combobox } = props;
     if (menuItems && menuItems.length) {
       const menuProps = {};
       if (multiple) {
@@ -58,6 +58,7 @@ const DropdownMenu = React.createClass({
       } else {
         menuProps.onClick = onMenuSelect;
       }
+
       const selectedKeys = getSelectKeys(menuItems, value);
       const activeKeyProps = {};
 
@@ -88,6 +89,11 @@ const DropdownMenu = React.createClass({
           }
           return clone(item);
         });
+      }
+
+      // clear activeKey when combobox mode
+      if (combobox) {
+        activeKeyProps.activeKey = '';
       }
 
       return (<Menu

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -83,7 +83,7 @@ const SelectTrigger = React.createClass({
   },
   render() {
     const props = this.props;
-    const { multiple, visible } = props;
+    const { multiple, visible, combobox } = props;
     const dropdownPrefixCls = this.getDropdownPrefixCls();
     const popupClassName = {
       [props.dropdownClassName]: !!props.dropdownClassName,
@@ -96,6 +96,7 @@ const SelectTrigger = React.createClass({
       menuItems: props.options,
       search,
       multiple,
+      combobox,
       visible,
     });
     return (<Trigger {...props}


### PR DESCRIPTION
当搜索建议模式时，选中某项之后，当前菜单的 active 状态不会清除。导致再次输入字符并回车时（原有的 options 不变的情况下），会重置回前面选中的值。

![](https://os.alipayobjects.com/rmsportal/NTcWFTOsRhVpVdA.png)

相关：https://github.com/react-component/menu/pull/26