### PR TITLE
Add min-width for select dropdown

### DIFF
--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -38,10 +38,15 @@ const SelectTrigger = React.createClass({
   },
 
   componentDidUpdate() {
-    if (this.props.dropdownMatchSelectWidth && this.props.visible) {
+    if (this.props.visible) {
       const dropdownDOMNode = this.getPopupDOMNode();
-      if (dropdownDOMNode) {
+      if (!dropdownDOMNode) {
+        return;
+      }
+      if (this.props.dropdownMatchSelectWidth) {
         dropdownDOMNode.style.width = `${ReactDOM.findDOMNode(this).offsetWidth}px`;
+      } else {
+        dropdownDOMNode.style.minWidth = `${ReactDOM.findDOMNode(this).offsetWidth}px`;
       }
     }
   },


### PR DESCRIPTION
始终添加 `min-width`，避免 `dropdownMatchWidth={false}` 时下图的问题：

![](https://os.alipayobjects.com/rmsportal/xXBWkVfoRZXfwKb.png)