### PR TITLE
优化对 value 为空的判断

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -37,7 +37,7 @@ export function isSingleMode(props) {
 
 export function toArray(value) {
   let ret = value;
-  if (value === undefined) {
+  if (value == undefined || value === '') {
     ret = [];
   } else if (!Array.isArray(value)) {
     ret = [value];

--- a/src/util.js
+++ b/src/util.js
@@ -37,7 +37,7 @@ export function isSingleMode(props) {
 
 export function toArray(value) {
   let ret = value;
-  if (value == undefined || value === '') {
+  if (value === undefined || value === null || value === '') {
     ret = [];
   } else if (!Array.isArray(value)) {
     ret = [value];


### PR DESCRIPTION
当组件传入`value`的值默认为`null`或空字符串时，是否也可以认定为`value`并没有设置值，即为`undefined`？

在项目中有碰到这样的场景，组件包含`allowClear`属性，然后`value`的初始值为`null`，而不是`undefined`，此时鼠标滑过时，会显示清除按钮（当然将`value`初始值设置为`undefined`完全可以避免这种情况）。

http://codepen.io/ystarlongzi/pen/xRVNVe