### PR TITLE
 Fix issue that onFocus will trigger twice

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -339,7 +339,10 @@ const Select = React.createClass({
     }
   },
 
-  onOuterFocus() {
+  onOuterFocus(e) {
+    if (e.target === this.getInputDOMNode()) {
+      return;
+    }
     this.clearBlurTime();
     this._focused = true;
     this.updateFocusClassName();


### PR DESCRIPTION
 + close https://github.com/ant-design/ant-design/issues/4576
 + 原因：this.mabeFocus 中，inputElement 的 focus 会再触发一次 onFocus