### PR TITLE
 Add an internal variable to fix dropdown visibility

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -124,6 +124,7 @@ const Select = React.createClass({
     }
     this.saveInputRef = saveRef.bind(this, 'inputInstance');
     this.saveInputMirrorRef = saveRef.bind(this, 'inputMirrorInstance');
+    this._justSelected = false;
     let open = props.open;
     if (open === undefined) {
       open = props.defaultOpen;
@@ -205,6 +206,7 @@ const Select = React.createClass({
         key: val,
       }]);
     }
+    this._justSelected = false;
   },
 
   onDropdownVisibleChange(open) {
@@ -307,6 +309,7 @@ const Select = React.createClass({
         title: selectedTitle,
       }];
       this.setOpenState(false, true);
+      this._justSelected = true;
     }
     this.fireChange(value);
     let inputValue;
@@ -721,7 +724,7 @@ const Select = React.createClass({
   },
 
   adjustOpenState() {
-    if (this.skipAdjustOpen) {
+    if (this.skipAdjustOpen || this._justSelected) {
       return;
     }
     let { open } = this.state;


### PR DESCRIPTION
 + close https://github.com/ant-design/ant-design/issues/4393
 + close https://github.com/ant-design/ant-design/issues/4804

https://github.com/react-component/select/blob/master/src/Select.jsx#L728

输入，选择一个选项 ，触发 onChange， 异步改变 options , 触发 componentWillUpdate, 于是进入 `adjustOpenState`，进行如下判断。

此时焦点仍然在 input 里，会强制把下拉框再弹出。但是用户已经完成了选择，其实不应该弹。

```jsx
if (typeof document !== 'undefined' &&
      this.getInputDOMNode() &&
      document.activeElement === this.getInputDOMNode()) {
      open = true;
   }

```


于是加了一个 `_justSelected` ，标记是否刚刚完成选择。如果刚刚完成选择，之后不会再强制打开下拉菜单。当用户有新的输入时，_justSelected 置为 false。

