### PR TITLE
Fire search event only when inputValue changes

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -572,11 +572,13 @@ const Select = React.createClass({
     });
   },
   setInputValue(inputValue, fireSearch = true) {
-    this.setState({
-      inputValue,
-    });
-    if (fireSearch) {
-      this.props.onSearch(inputValue);
+    if (inputValue !== this.state.inputValue) {
+      this.setState({
+        inputValue,
+      });
+      if (fireSearch) {
+        this.props.onSearch(inputValue);
+      }
     }
   },
   clearBlurTime() {

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -241,6 +241,23 @@ describe('Select', () => {
     expect(handleSearch).toBeCalledWith('1');
   });
 
+  it('not fires search event when user select', () => {
+    const handleSearch = jest.fn();
+    const wrapper = mount(
+      <Select
+        showSearch
+        onSearch={handleSearch}
+      >
+        <Option value="1">1</Option>
+        <Option value="2">2</Option>
+      </Select>
+    );
+    wrapper.find('.rc-select').simulate('click');
+    const dropdownWrapper = mount(wrapper.find('Trigger').node.getComponent());
+    dropdownWrapper.find('MenuItem').first().simulate('click');
+    expect(handleSearch).not.toBeCalled();
+  });
+
   describe('focus', () => {
     let handleFocus;
     let wrapper;


### PR DESCRIPTION
碰到的问题是，在 input 为空的情况下选择一个选项，这时会同时触发 `onSelect` 和 `onSearch`，且 `onSearch` 得到的参数是个空字符串，这个 `onSearch` 是多余的。