### PR TITLE
 Customize Input Element of Select bug

### DIFF
--- a/examples/suggest.js
+++ b/examples/suggest.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Select, { Option } from 'rc-select';
+import { Input } from 'antd';
 import 'rc-select/assets/index.less';
 import { fetch } from './common/tbFetchSuggest';
 import ReactDOM from 'react-dom';
@@ -57,6 +58,7 @@ const Search = React.createClass({
           value={this.state.value}
           placeholder="placeholder"
           defaultActiveFirstOption={false}
+          getInputElement={() => <Input />}
           showArrow={false}
           notFoundContent=""
           onChange={this.fetchData}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -702,7 +702,8 @@ const Select = React.createClass({
       options = this.renderFilterOptions();
     }
     this._options = options;
-     if (isMultipleOrTagsOrCombobox(this.props) || !this.props.showSearch) {
+
+    if (isMultipleOrTagsOrCombobox(this.props) || !this.props.showSearch) {
       if (open && !options.length) {
         open = false;
       }

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -495,7 +495,9 @@ const Select = React.createClass({
   },
 
   getInputDOMNode() {
-    return this.inputInstance;
+    return this.topCtrlNode ?
+       this.topCtrlNode.querySelector('input,textarea,div[contentEditable]') :
+       this.inputInstance;
   },
 
   getInputMirrorDOMNode() {
@@ -700,9 +702,10 @@ const Select = React.createClass({
       options = this.renderFilterOptions();
     }
     this._options = options;
-    if (open &&
-      (isMultipleOrTagsOrCombobox(this.props) || !this.props.showSearch) && !options.length) {
-      open = false;
+     if (isMultipleOrTagsOrCombobox(this.props) || !this.props.showSearch) {
+      if (open && !options.length) {
+        open = false;
+      }
     }
     this.state.open = open;
   },
@@ -812,7 +815,13 @@ const Select = React.createClass({
         innerNode = <ul>{selectedValueNodes}</ul>;
       }
     }
-    return (<div className={className}>{this.getPlaceholderElement()}{innerNode}</div>);
+    return (<div
+      className={className}
+      ref={node => this.topCtrlNode = node}
+    >
+      {this.getPlaceholderElement()}
+      {innerNode}
+    </div>);
   },
 
   render() {


### PR DESCRIPTION
 + ref https://github.com/ant-design/ant-design/issues/5601
 + getInputDOMNode cannot get correct input element, so `document.activeElement
 === this.getInputDOMNode())` will always false.
 + add scheme of `getInputElement`: if getInputElement returns an `React.Element`, the element must implemented `refs.input` to point to its real input element.