### PR TITLE
Add option to prevent triggering onChange event after onSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ React.render(c, container);
 |combobox | enable combobox mode(can not set multiple at the same time) | bool | false |
 |multiple | whether multiple select | bool | false |
 |disabled | whether disabled select | bool | false |
+|triggerOnchange | trigger input onChange event after an option is selected(onSelect) | bool | true |
 |filterOption | whether filter options by input value. default filter by option's optionFilterProp prop's value | bool | true/Function(inputValue:string, option:Option) |
 |optionFilterProp | which prop value of option will be used for filter if filterOption is true | String | 'value' |
 |optionLabelProp | which prop value of option will render as content of select | String | 'value' |

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -40,6 +40,7 @@ export const SelectPropTypes = {
   showSearch: PropTypes.bool,
   disabled: PropTypes.bool,
   allowClear: PropTypes.bool,
+  triggerOnchange: PropTypes.bool,
   showArrow: PropTypes.bool,
   tags: PropTypes.bool,
   prefixCls: PropTypes.string,

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -271,8 +271,9 @@ const Select = React.createClass({
       this.setOpenState(false, true);
     }
     this.fireChange(value);
+
     let inputValue;
-    if (isCombobox(props)) {
+    if (isCombobox(props) && props.triggerOnchange) {
       inputValue = getPropValue(item, props.optionLabelProp);
     } else {
       inputValue = '';
@@ -640,10 +641,7 @@ const Select = React.createClass({
       }
       props.onDeselect(event);
     }
-    
-    if (props.triggerOnchange) {
-      this.fireChange(value);
-    }
+    this.fireChange(value);
   },
 
   openIfHasChildren() {

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -52,6 +52,7 @@ const Select = React.createClass({
       defaultActiveFirstOption: true,
       showSearch: true,
       allowClear: false,
+      triggerOnchange: true,
       placeholder: '',
       onChange: noop,
       onFocus: noop,
@@ -639,7 +640,10 @@ const Select = React.createClass({
       }
       props.onDeselect(event);
     }
-    this.fireChange(value);
+    
+    if (props.triggerOnchange) {
+      this.fireChange(value);
+    }
   },
 
   openIfHasChildren() {

--- a/tests/Select.triggerOnchange.spec.js
+++ b/tests/Select.triggerOnchange.spec.js
@@ -19,7 +19,7 @@ describe('test test test', () => {
     expect(wrapper.state().inputValue).toBe('1');
   });
 
-  it('not fires input change when triggerOnchange is true ', () => {
+  it('not fires input change when triggerOnchange is false ', () => {
     const wrapper = mount(
       <Select combobox triggerOnchange={false}>
         <Option value="1">1</Option>

--- a/tests/Select.triggerOnchange.spec.js
+++ b/tests/Select.triggerOnchange.spec.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import { mount } from 'enzyme';
+import Select, { Option } from '../src';
+
+describe('test test test', () => {
+  it('fires input change by default ', () => {
+    const wrapper = mount(
+      <Select combobox>
+        <Option value="1">1</Option>
+        <Option value="2">2</Option>
+      </Select>
+    );
+
+    wrapper.find('.rc-select').simulate('click');
+    const dropdownWrapper = mount(wrapper.find('Trigger').node.getComponent());
+
+    dropdownWrapper.find('MenuItem').first().simulate('click');
+    expect(wrapper.state().inputValue).toBe('1');
+  });
+
+  it('not fires input change when triggerOnchange is true ', () => {
+    const wrapper = mount(
+      <Select combobox triggerOnchange={false}>
+        <Option value="1">1</Option>
+        <Option value="2">2</Option>
+      </Select>
+    );
+
+    wrapper.find('.rc-select').simulate('click');
+    const dropdownWrapper = mount(wrapper.find('Trigger').node.getComponent());
+
+    dropdownWrapper.find('MenuItem').first().simulate('click');
+    expect(wrapper.state().inputValue).toBe('');
+  });
+});


### PR DESCRIPTION
- ref https://github.com/ant-design/ant-design/issues/5610
- `onChange` is always triggering after `onSelect`, cannot set/clear values by `setState`
- add `triggerOnchange` which will be `true` by default, so you can prevent firing input `onChange` after option selection