### PR TITLE
Migrated deprecated React.PropTypes and React.createClass

### DIFF
--- a/examples/combobox.js
+++ b/examples/combobox.js
@@ -2,10 +2,11 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       disabled: false,

--- a/examples/email.js
+++ b/examples/email.js
@@ -1,11 +1,12 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import ReactDOM from 'react-dom';
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       options: [],

--- a/examples/force-suggest.js
+++ b/examples/force-suggest.js
@@ -1,12 +1,13 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import { fetch } from './common/tbFetchSuggest';
 import ReactDOM from 'react-dom';
 
-const Search = React.createClass({
+const Search = createReactClass({
   getInitialState() {
     return {
       disabled: false,

--- a/examples/getPopupContainer.js
+++ b/examples/getPopupContainer.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import Dialog from 'rc-dialog';
 import 'rc-dialog/assets/index.css';
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       open: false,

--- a/examples/mul-suggest.js
+++ b/examples/mul-suggest.js
@@ -1,12 +1,13 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import { fetch } from './common/tbFetchSuggest';
 import ReactDOM from 'react-dom';
 
-const Search = React.createClass({
+const Search = createReactClass({
   getInitialState() {
     return {
       data: [],

--- a/examples/mul-tag-suggest.js
+++ b/examples/mul-tag-suggest.js
@@ -1,12 +1,13 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import { fetch } from './common/tbFetchSuggest';
 import ReactDOM from 'react-dom';
 
-const Search = React.createClass({
+const Search = createReactClass({
   getInitialState() {
     return {
       data: [],

--- a/examples/multiple-readonly.js
+++ b/examples/multiple-readonly.js
@@ -1,5 +1,6 @@
 /* eslint no-console: 0 */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import ReactDOM from 'react-dom';
@@ -10,7 +11,7 @@ for (let i = 10; i < 36; i++) {
   children.push(<Option disabled={i === 11} key={i.toString(36) + i}>中文{i}</Option>);
 }
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       value: ['b11'],

--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -1,6 +1,7 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import ReactDOM from 'react-dom';
@@ -22,7 +23,7 @@ function onDeselect() {
   console.log(arguments);
 }
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       useAnim: 0,

--- a/examples/single.js
+++ b/examples/single.js
@@ -1,11 +1,12 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import ReactDOM from 'react-dom';
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       destroy: false,

--- a/examples/suggest.js
+++ b/examples/suggest.js
@@ -1,6 +1,7 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import { fetch } from './common/tbFetchSuggest';
@@ -8,7 +9,7 @@ import ReactDOM from 'react-dom';
 
 const Input = (props) => <input {...props} />;
 
-const Search = React.createClass({
+const Search = createReactClass({
   getInitialState() {
     return {
       data: [],

--- a/examples/tags.js
+++ b/examples/tags.js
@@ -1,6 +1,7 @@
 /* eslint no-console: 0 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Select, { Option } from 'rc-select';
 import 'rc-select/assets/index.less';
 import ReactDOM from 'react-dom';
@@ -10,7 +11,7 @@ for (let i = 10; i < 36; i++) {
   children.push(<Option key={i.toString(36) + i}>{i.toString(36) + i}</Option>);
 }
 
-const Test = React.createClass({
+const Test = createReactClass({
   getInitialState() {
     return {
       disabled: false,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "collectCoverageFrom": [
       "src/**/*"
     ],
-    "snapshotSerializers": ["enzyme-to-json/serializer"]
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   },
   "devDependencies": {
     "babel-jest": "^17.0.0",
@@ -64,7 +66,9 @@
     "babel-runtime": "6.x",
     "classnames": "2.x",
     "component-classes": "1.x",
+    "create-react-class": "^15.5.2",
     "dom-scroll-into-view": "1.x",
+    "prop-types": "^15.5.8",
     "rc-animate": "2.x",
     "rc-menu": "5.x || 4.x",
     "rc-trigger": "1.x",

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -1,11 +1,13 @@
-import React, { cloneElement, PropTypes } from 'react';
+import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import { findDOMNode } from 'react-dom';
 import toArray from 'rc-util/lib/Children/toArray';
 import Menu from 'rc-menu';
 import scrollIntoView from 'dom-scroll-into-view';
 import { getSelectKeys, preventDefaultEvent } from './util';
 
-const DropdownMenu = React.createClass({
+const DropdownMenu = createReactClass({
   propTypes: {
     defaultActiveFirstOption: PropTypes.bool,
     value: PropTypes.any,

--- a/src/Option.jsx
+++ b/src/Option.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Option extends React.Component {
   static propTypes = {
-    value: React.PropTypes.string,
+    value: PropTypes.string,
   };
 
   static isSelectOption = true;

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -4,6 +4,7 @@ import KeyCode from 'rc-util/lib/KeyCode';
 import classnames from 'classnames';
 import Animate from 'rc-animate';
 import classes from 'component-classes';
+import createReactClass from 'create-react-class';
 import {
   getPropValue, getValuePropValue, isCombobox,
   isMultipleOrTags, isMultipleOrTagsOrCombobox,
@@ -38,7 +39,7 @@ function chaining(...fns) {
   };
 }
 
-const Select = React.createClass({
+const Select = createReactClass({
   propTypes: SelectPropTypes,
 
   mixins: [FilterMixin],

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -1,5 +1,7 @@
 import Trigger from 'rc-trigger';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import classnames from 'classnames';
 import DropdownMenu from './DropdownMenu';
 import ReactDOM from 'react-dom';
@@ -24,7 +26,7 @@ const BUILT_IN_PLACEMENTS = {
   },
 };
 
-const SelectTrigger = React.createClass({
+const SelectTrigger = createReactClass({
   propTypes: {
     onPopupFocus: PropTypes.func,
     dropdownMatchSelectWidth: PropTypes.bool,

--- a/tests/FilterMixin.spec.js
+++ b/tests/FilterMixin.spec.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-undef */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import FilterMixin from '../src/FilterMixin';
 import Menu from 'rc-menu';
 import OptGroup from '../src/OptGroup';
@@ -7,7 +9,7 @@ import Option from '../src/Option';
 import { render, mount } from 'enzyme';
 
 describe('FilterMixin', () => {
-  const Select = React.createClass({
+  const Select = createReactClass({
     propTypes: {
       value: PropTypes.any,
       inputValue: PropTypes.string,


### PR DESCRIPTION
 - as React.PropTypes, React.createClass is being deprecated
 - Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
 - Solution: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes