### PR TITLE
Focus and blur issues

### DIFF
--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -90,6 +90,7 @@ const DropdownMenu = createClass({
           if (!foundFirst && selectedKeys.indexOf(item.key) !== -1) {
             foundFirst = true;
             return cloneElement(item, {
+              onKeyDown: () => console.log(' item keydown'),
               ref: (ref) => {
                 this.firstActiveItem = ref;
               },

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -90,7 +90,6 @@ const DropdownMenu = createClass({
           if (!foundFirst && selectedKeys.indexOf(item.key) !== -1) {
             foundFirst = true;
             return cloneElement(item, {
-              onKeyDown: () => console.log(' item keydown'),
               ref: (ref) => {
                 this.firstActiveItem = ref;
               },

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -350,7 +350,7 @@ const Select = createClass({
         this.state.inputValue = this.getInputDOMNode().value = '';
       }
       props.onBlur(this.getVLForOnChange(value));
-    }, 50);
+    }, 10);
   },
 
   onClearSelection(event) {

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -256,7 +256,9 @@ describe('Select', () => {
           <Option value="2">2</Option>
         </Select>
       );
+      jest.useFakeTimers();
       wrapper.find('.rc-select').simulate('focus');
+      jest.runAllTimers();
     });
 
     it('set _focused to true', () => {
@@ -265,6 +267,37 @@ describe('Select', () => {
 
     it('fires focus event', () => {
       expect(handleFocus).toBeCalled();
+      expect(handleFocus.mock.calls.length).toBe(1);
+    });
+
+    it('set className', () => {
+      expect(wrapper.find('.rc-select').node.className).toContain('-focus');
+    });
+  });
+
+  describe('click input will trigger focus', () => {
+    let handleFocus;
+    let wrapper;
+    beforeEach(() => {
+      handleFocus = jest.fn();
+      wrapper = mount(
+        <Select onFocus={handleFocus}>
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>
+      );
+      jest.useFakeTimers();
+      wrapper.find('.rc-select input').simulate('click');
+      jest.runAllTimers();
+    });
+
+    it('set _focused to true', () => {
+      expect(wrapper.instance()._focused).toBe(true);
+    });
+
+    it('fires focus event', () => {
+      expect(handleFocus).toBeCalled();
+      expect(handleFocus.mock.calls.length).toBe(1);
     });
 
     it('set className', () => {


### PR DESCRIPTION
 + close https://github.com/ant-design/ant-design/issues/5741
 + close https://github.com/ant-design/ant-design/issues/5792
 + close https://github.com/ant-design/ant-design/issues/5778

There's a confusing `onFocus` flow:

Focus `<Select />`, onFocus trigger.
* `<Trigger/>` focus
* `<div />` focus, 
* `onOuterFocus()` => `props.onFocus()` // Select onFocus callback here
* `setPopupVisible()` =>`Trigger.onPopupVisibleChange()` => `setOpenState(true)`
* `<input />` get focus.

Focus `<input />`, onFocus not trigger
* `<Trigger />` focus
* `<input />` focus,
* `setPopupVisible()` =>`Trigger.onPopupVisibleChange()` => `setOpenState(true)`
* `<input /> ` already focus, do nothing.

