### PR TITLE
Add limit to the amount of selected tags shown

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -805,7 +805,7 @@ const Select = createClass({
         </li>);
       }
       if (isMultipleOrTags(props)) {
-        selectedValueNodes = value.map((singleValue) => {
+        selectedValueNodes = limitedCountValue.map((singleValue) => {
           let content = singleValue.label;
           const title = singleValue.title || content;
           if (maxTagTextLength &&

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -788,6 +788,22 @@ const Select = createClass({
       }
     } else {
       let selectedValueNodes = [];
+      let limitedCountValue = value;
+      let maxTagPlaceholder;
+      if (props.maxTagCount && value.length > props.maxTagCount) {
+        limitedCountValue = limitedCountValue.slice(0, props.maxTagCount);
+        const content = props.maxTagPlaceholder || `+ ${value.length - props.maxTagCount} ...`;
+        maxTagPlaceholder = (<li
+          style={UNSELECTABLE_STYLE}
+          {...UNSELECTABLE_ATTRIBUTE}
+          onMouseDown={preventDefaultEvent}
+          className={`${prefixCls}-selection__choice ${prefixCls}-selection__choice__disabled`}
+          key={'maxTagPlaceholder'}
+          title={content}
+        >
+          <div className={`${prefixCls}-selection__choice__content`}>{content}</div>
+        </li>);
+      }
       if (isMultipleOrTags(props)) {
         selectedValueNodes = value.map((singleValue) => {
           let content = singleValue.label;
@@ -820,6 +836,9 @@ const Select = createClass({
             </li>
           );
         });
+      }
+      if (maxTagPlaceholder) {
+        selectedValueNodes.push(maxTagPlaceholder);
       }
       selectedValueNodes.push(<li
         className={`${prefixCls}-search ${prefixCls}-search--inline`}


### PR DESCRIPTION
When having to select more than 100 options, all those tags become a performance issue. It's better to be able to treat the Select as a normal multiple select input, limiting the amount of selected tags:

![image](https://cloud.githubusercontent.com/assets/1778376/26309673/3e7fb356-3ed4-11e7-9155-98e3bd78fd46.png)
