### PR TITLE
Passing true to "filterOption" will return all options instead of those matching input

### DIFF
--- a/src/FilterMixin.js
+++ b/src/FilterMixin.js
@@ -13,14 +13,21 @@ export default {
     if (!input) {
       return true;
     }
-    const filterOption = ('filterOption' in this.props) ?
-      this.props.filterOption : defaultFilter;
-    if (!filterOption) {
+    let filterFn = this.props.filterOption;
+    if ('filterOption' in this.props) {
+      if (this.props.filterOption === true) {
+        filterFn = defaultFilter;
+      }
+    } else {
+      filterFn = defaultFilter;
+    }
+
+    if (!filterFn) {
       return true;
     } else if (child.props.disabled) {
       return false;
-    } else if (typeof filterOption === 'function') {
-      return filterOption.call(this, input, child);
+    } else if (typeof filterFn === 'function') {
+      return filterFn.call(this, input, child);
     }
     return true;
   },

--- a/tests/FilterMixin.spec.js
+++ b/tests/FilterMixin.spec.js
@@ -125,6 +125,17 @@ describe('FilterMixin', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('does not filter when filterOption value is false', () => {
+      const wrapper = render(
+        <Select inputValue="1" filterOption={false}>
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
     describe('tag mode', () => {
       it('renders unlisted item in value', () => {
         const wrapper = render(
@@ -137,7 +148,7 @@ describe('FilterMixin', () => {
         expect(wrapper).toMatchSnapshot();
       });
 
-      it('renders search value when not fount', () => {
+      it('renders search value when not found', () => {
         const wrapper = render(
           <Select tags value="22" inputValue="2">
             <Option value="1">1</Option>

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -126,7 +126,7 @@ describe('Select', () => {
     expect(wrapper.find('.rc-select-selection-selected-value').props().children).toBe('1');
   });
 
-  it('filter options by values', () => {
+  it('filter options by "value" prop by default', () => {
     const wrapper = mount(
       <Select>
         <Option value="1">One</Option>
@@ -137,6 +137,31 @@ describe('Select', () => {
     wrapper.find('input').simulate('change', { target: { value: '1' } });
     expect(wrapper.find('MenuItem').length).toBe(1);
     expect(wrapper.find('MenuItem').props().value).toBe('1');
+  });
+
+  it('should filter options when filterOption is true', () => {
+    const wrapper = mount(
+      <Select filterOption>
+        <Option value="1">One</Option>
+        <Option value="2">Two</Option>
+      </Select>
+    );
+
+    wrapper.find('input').simulate('change', { target: { value: '2' } });
+    expect(wrapper.find('MenuItem').length).toBe(1);
+    expect(wrapper.find('MenuItem').props().value).toBe('2');
+  });
+
+  it('should not filter options when filterOption is false', () => {
+    const wrapper = mount(
+      <Select filterOption={false}>
+        <Option value="1">One</Option>
+        <Option value="2">Two</Option>
+      </Select>
+    );
+
+    wrapper.find('input').simulate('change', { target: { value: '1' } });
+    expect(wrapper.find('MenuItem').length).toBe(2);
   });
 
   it('specify which prop to filter', () => {

--- a/tests/__snapshots__/FilterMixin.spec.js.snap
+++ b/tests/__snapshots__/FilterMixin.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FilterMixin renderFilterOptionsFromChildren filterOption could be true as described in default value 1`] = `
+exports[`FilterMixin renderFilterOptionsFromChildren does not filter when filterOption value is false 1`] = `
 <ul
   aria-activedescendant=""
   class="rc-menu rc-menu-vertical  rc-menu-root"
@@ -26,6 +26,15 @@ exports[`FilterMixin renderFilterOptionsFromChildren filterOption could be true 
     2
   </li>
 </ul>
+`;
+
+exports[`FilterMixin renderFilterOptionsFromChildren filterOption could be true as described in default value 1`] = `
+<ul
+  aria-activedescendant=""
+  class="rc-menu rc-menu-vertical  rc-menu-root"
+  role="menu"
+  tabindex="0"
+/>
 `;
 
 exports[`FilterMixin renderFilterOptionsFromChildren filters children by inputValue 1`] = `
@@ -99,7 +108,7 @@ exports[`FilterMixin renderFilterOptionsFromChildren renders options correctly 1
 </ul>
 `;
 
-exports[`FilterMixin renderFilterOptionsFromChildren tag mode renders search value when not fount 1`] = `
+exports[`FilterMixin renderFilterOptionsFromChildren tag mode renders search value when not found 1`] = `
 <ul
   aria-activedescendant=""
   class="rc-menu rc-menu-vertical  rc-menu-root"

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-undef */
-import { includesSeparators, splitBySeparators, getValuePropValue } from '../src/util';
+import {
+  includesSeparators,
+  splitBySeparators,
+  getValuePropValue,
+  defaultFilterFn,
+} from '../src/util';
 
 describe('includesSeparators', () => {
   const separators = [' ', ','];
@@ -65,5 +70,27 @@ describe('getValuePropValue', () => {
       },
     })).toBe('Manager');
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('defaultFilterFn', () => {
+  function TesterClass() {
+    this.props = {
+      optionFilterProp: 'label',
+    };
+  }
+  const testerInstance = new TesterClass();
+  const child = {
+    props: {
+      label: 'my-val',
+    },
+  };
+
+  it('returns true when input matches option value', () => {
+    expect(defaultFilterFn.call(testerInstance, 'my-val', child)).toBe(true);
+  });
+
+  it('returns false when input does NOT match option value', () => {
+    expect(defaultFilterFn.call(testerInstance, 'wrong-val', child)).toBe(false);
   });
 });


### PR DESCRIPTION
I discovered this issue when using ant-design. Since Ant-Design defaults filterOption to false I needed to pass set filterOption to true. When I did that I discovered that no options were being filtered. Here is a [codepen](https://codepen.io/gklinsing/pen/MooJJZ) showing this.

I tracked the problem line down to [FilterMixin.js#L16](https://github.com/react-component/select/blob/master/src/FilterMixin.js#L16). When you pass in true it doesn't use defaultFilter, but rather returns true for each option.