### PR TITLE
Allow Number type value in Select Option

### DIFF
--- a/src/Option.jsx
+++ b/src/Option.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 
 export default class Option extends React.Component {
   static propTypes = {
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
   };
 
   static isSelectOption = true;

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -31,7 +31,7 @@ function valueType(props, propName, componentName) {
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.arrayOf(PropTypes.number),
       PropTypes.string,
-      PropTypes.number
+      PropTypes.number,
     ]);
     return validate(...arguments);
   }

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 
 function valueType(props, propName, componentName) {
   const labelInValueShape = PropTypes.shape({
-    key: PropTypes.string.isRequired,
+    key: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]).isRequired,
     label: PropTypes.string,
   });
   if (props.labelInValue) {
@@ -15,18 +18,20 @@ function valueType(props, propName, componentName) {
       return new Error(
         `Invalid prop \`${propName}\` supplied to \`${componentName}\`, ` +
           `when you set \`labelInValue\` to \`true\`, \`${propName}\` should in ` +
-          `shape of \`{ key: string, label?: string }\`.`
+          `shape of \`{ key: string || number, label?: string }\`.`
       );
     }
   } else if (props.multiple && props[propName] === '') {
     return new Error(
-      `Invalid prop \`${propName}\` of type \`string\` supplied to \`${componentName}\`, ` +
+      `Invalid prop \`${propName}\` supplied to \`${componentName}\`, ` +
         `expected \`array\` when \`multiple\` is \`true\`.`
     );
   } else {
     const validate = PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
+      PropTypes.arrayOf(PropTypes.number),
       PropTypes.string,
+      PropTypes.number
     ]);
     return validate(...arguments);
   }

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -538,7 +538,7 @@ describe('Select', () => {
       expect(spy.mock.calls[0][0]).toMatch(
         'Warning: Failed prop type: Invalid prop `value` supplied to `Select`, ' +
         'when you set `labelInValue` to `true`,' +
-        ' `value` should in shape of `{ key: string, label?: string }`'
+        ' `value` should in shape of `{ key: string || number, label?: string }`'
       );
     });
 
@@ -547,7 +547,7 @@ describe('Select', () => {
         <Select multiple value="" />
       );
       expect(spy.mock.calls[0][0]).toMatch(
-        'Warning: Failed prop type: Invalid prop `value` of type `string` supplied to `Select`, ' +
+        'Warning: Failed prop type: Invalid prop `value` supplied to `Select`, ' +
         'expected `array` when `multiple` is `true`'
       );
     });


### PR DESCRIPTION
Updated Option proptypes to allow Number type in the value attribute.
Issue: #115 and [Ant Design #2857](https://github.com/ant-design/ant-design/issues/2857)
 