### PR TITLE
Fix Multiple Repeating Separators Issue

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -135,14 +135,7 @@ export function includesSeparators(string, separators) {
 
 export function splitBySeparators(string, separators) {
   const reg = new RegExp(`[${separators.join()}]`);
-  const array = string.split(reg);
-  while (array[0] === '') {
-    array.shift();
-  }
-  while (array[array.length - 1] === '') {
-    array.pop();
-  }
-  return array;
+  return string.split(reg).filter(token => token);
 }
 
 export function defaultFilterFn(input, child) {

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -47,6 +47,16 @@ describe('splitBySeparators', () => {
     const string = ',,';
     expect(splitBySeparators(string, separators)).toEqual([]);
   });
+
+  it('split two separators surrounded by valid input', () => {
+    const string = 'a,,b';
+    expect(splitBySeparators(string, separators)).toEqual(['a', 'b']);
+  });
+
+  it('split multiple separators with valid input throughout', () => {
+    const string = ',,,a,b,,,c,d,,,e,';
+    expect(splitBySeparators(string, separators)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
 });
 
 describe('getValuePropValue', () => {

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -53,9 +53,14 @@ describe('splitBySeparators', () => {
     expect(splitBySeparators(string, separators)).toEqual(['a', 'b']);
   });
 
-  it('split multiple separators with valid input throughout', () => {
+  it('split repeating separators with valid input throughout', () => {
     const string = ',,,a,b,,,c,d,,,e,';
     expect(splitBySeparators(string, separators)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('split multiple repeating separators with valid input throughout', () => {
+    const string = ',,,a b,  c,d, ,e    ,f';
+    expect(splitBySeparators(string, separators)).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
   });
 });
 


### PR DESCRIPTION
Hello,

I found this issue because of this component's usage in AntDesign. There was actually another issue filed there for a very similar problem that was already fixed in this repo: https://github.com/ant-design/ant-design/issues/5831

What I found is that, if I paste in input that contains multiple separators *followed by valid input*, it crashes their Select component. I traced it back to here.

In the fix provided for https://github.com/ant-design/ant-design/issues/5831 in  https://github.com/react-component/select/commit/b4c7c3e2de7286df33366832c9676e6f8fc1823a, the solution effectively implements `String.prototype.trim` on the array representing the string - i.e. empty elements at the beginning and the end of the array will be trimmed off.

What this solution did not account for is cases where the input contains a mixture of these scenarios, i.e.:
`,,a,,,,b,,d,e,f,,g,,,`

In this case, you end up with:
```
["a", "", "", "", "b", "", "d", "e", "f", "", "g",]
```

My changes condense the function to two lines which effectively do this:
- Split the string according to the separators
- Filter out any entries in the resulting array that are falsy (i.e. empty elements)

There are also relevant test cases for the issue.

Additionally, here's a reproducible version from your demo:
[rc-select@6.9.5: Tags Demo](http://react-component.github.io/select/examples/tags.html)
   - Paste in the following input: `tag1,,,,,,,,,tag2`
   - Notice that a space appears between the two elements, and if inspecting the HTML, notice that a blank tag has rendered there



Let me know what you think - hope we can get it merged quickly if you're happy with it.