### PR TITLE
fix: the children should traversed by using standard api `React.Children`

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -2,9 +2,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import KeyCode from 'rc-util/lib/KeyCode';
+import childrenToArray from 'rc-util/lib/Children/toArray';
 import classnames from 'classnames';
 import Animate from 'rc-animate';
 import classes from 'component-classes';
+import { Item as MenuItem, ItemGroup as MenuItemGroup } from 'rc-menu';
+import warning from 'warning';
+
 import {
   getPropValue,
   getValuePropValue,
@@ -27,8 +31,6 @@ import {
 } from './util';
 import SelectTrigger from './SelectTrigger';
 import { SelectPropTypes } from './PropTypes';
-import { Item as MenuItem, ItemGroup as MenuItemGroup } from 'rc-menu';
-import warning from 'warning';
 
 function noop() {}
 
@@ -812,7 +814,7 @@ export default class Select extends React.Component {
   };
 
   isChildDisabled = key => {
-    return toArray(this.props.children).some(child => {
+    return childrenToArray(this.props.children).some(child => {
       const childValue = getValuePropValue(child);
       return childValue === key && child.props && child.props.disabled;
     });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,4 @@
-global.requestAnimationFrame = global.requestAnimationFrame || function (cb) {
+global.requestAnimationFrame = global.requestAnimationFrame || function requestAnimationFrame(cb) {
   return setTimeout(cb, 0);
 };
 


### PR DESCRIPTION
fixed #241 

Should use `React.Children` to traverse the children of a react element. Now that there is a common utility is capable of achieving this, use it instead:

https://github.com/react-component/util/blob/8d5c97fadfd353c75ec058ec310c76ed530f733b/src/Children/toArray.js#L3

BTW, I added the missing name of mock function `requestAnimationFrame` which causes the warning of lint.