### PR TITLE
add tooltip for aggregated tag placeholder element (maxTagCount)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ React.render(c, container);
 |allowClear | whether allowClear | bool | false |
 |tags | when tagging is enabled the user can select from pre-existing options or create a new tag by picking the first choice, which is what the user has typed into the search box so far. | bool | false |
 |maxTagTextLength | max tag text length to show | number | - |
+|maxTagCount | Ony display the max number of tags, aggregate the rest tags within one pillow | number | - |
 |combobox | enable combobox mode(can not set multiple at the same time) | bool | false |
 |multiple | whether multiple select | bool | false |
 |disabled | whether disabled select | bool | false |

--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -74,6 +74,7 @@ class Test extends React.Component {
             onChange={this.onChange}
             onFocus={() => console.log('focus')}
             tokenSeparators={[' ', ',']}
+            maxTagCount={3}
           >
             {children}
           </Select>

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -8,6 +8,7 @@ import Animate from 'rc-animate';
 import classes from 'component-classes';
 import { Item as MenuItem, ItemGroup as MenuItemGroup } from 'rc-menu';
 import warning from 'warning';
+import Trigger from 'rc-trigger';
 
 import {
   getPropValue,
@@ -1005,6 +1006,33 @@ export default class Select extends React.Component {
     return sel;
   };
 
+  renderPopUp = (items) => {
+    return (
+      <div
+        style={{
+          border: '1px solid #666',
+          paddingLeft: 10,
+          paddingRight: 10,
+          paddingBottom: 5,
+          background: 'white',
+          maxHeight: '200px',
+          width: '200px',
+          overflow: 'auto',
+        }}
+      >
+        <ul style={{ paddingLeft: 0, listStyleType: 'none', margin: 0 }}>
+          {items.map(item => (
+            <li
+              key={item.key}
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
   renderTopControlNode = () => {
     const { value, open, inputValue } = this.state;
     const props = this.props;
@@ -1070,10 +1098,26 @@ export default class Select extends React.Component {
     } else {
       let selectedValueNodes = [];
       let limitedCountValue = value;
+      let maxTagValue = [];
       let maxTagPlaceholderEl;
       if (maxTagCount && value.length > maxTagCount) {
         limitedCountValue = limitedCountValue.slice(0, maxTagCount);
-        const content = maxTagPlaceholder || `+ ${value.length - maxTagCount} ...`;
+        maxTagValue = value.slice(maxTagCount, value.length);
+        const content = maxTagPlaceholder || (
+          <Trigger
+            action={['hover']}
+            popup={this.renderPopUp(maxTagValue)}
+            destroyPopupOnHide
+            popupAlign={{
+              points: ['tl', 'bl'],
+              offset: [0, 3],
+            }}
+          >
+            <div className={`${prefixCls}-selection__choice__content`}>
+              {`+ ${value.length - maxTagCount} ...`}
+            </div>
+          </Trigger>
+        );
         maxTagPlaceholderEl = (<li
           style={UNSELECTABLE_STYLE}
           {...UNSELECTABLE_ATTRIBUTE}
@@ -1082,7 +1126,7 @@ export default class Select extends React.Component {
           key={'maxTagPlaceholder'}
           title={content}
         >
-          <div className={`${prefixCls}-selection__choice__content`}>{content}</div>
+          {content}
         </li>);
       }
       if (isMultipleOrTags(props)) {

--- a/tests/__snapshots__/Select.multiple.spec.js.snap
+++ b/tests/__snapshots__/Select.multiple.spec.js.snap
@@ -170,7 +170,7 @@ exports[`Select.multiple render truncates tags by maxTagCount 1`] = `
         <li
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
-          title="+ 1 ..."
+          title="[object Object]"
           unselectable="unselectable"
         >
           <div

--- a/tests/__snapshots__/Select.tags.spec.js.snap
+++ b/tests/__snapshots__/Select.tags.spec.js.snap
@@ -170,7 +170,7 @@ exports[`Select.tags render truncates tags by maxTagCount 1`] = `
         <li
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
-          title="+ 1 ..."
+          title="[object Object]"
           unselectable="unselectable"
         >
           <div


### PR DESCRIPTION
I noticed that the PR got merged for `maxTagCount`, but users would want to have a way to know what they have selected. So I added this simple tooltip using rc-trigger. The tooltip allows multi-way scroll because in my use case, some item names are very long and users want to see the full name.