### PR TITLE
Improve behaviour on blur

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -381,6 +381,11 @@ export default class Select extends React.Component {
                 label: this.getLabelFromOption(firstOption),
               },
             ];
+            
+            /* Close dropdown so the unfiltering caused by fireChange()
+               does not cause the dropdown to animate and expand just
+               before closing again. */
+            this.setOpenState(false);
             this.fireChange(value);
           }
         }


### PR DESCRIPTION
I'm using something similar to the following code. This is one of the examples from https://ant.design/components/select/

```
<Select
    showSearch
    style={{ width: 200 }}
    placeholder="Select a person"
    optionFilterProp="children"
    onChange={handleChange}
    onFocus={handleFocus}
    onBlur={handleBlur}
    filterOption={(input, option) => option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0}
  >
    <Option value="jack">Jack</Option>
    <Option value="lucy">Lucy</Option>
    <Option value="tom">Tom</Option>
  </Select>
```

When typing "jack" and then pressing TAB, the dropdown box briefly expands just before closing again.

![select-issue](https://user-images.githubusercontent.com/78237/34220028-5c3f5460-e5b3-11e7-9211-eff4b2f3d6a2.gif)

This patch fixes that behaviour by setting the open state to closed just before firing the change, instead of afterwards.