### PR TITLE
fix: tag display correct when maxTagCount value is 0

### DIFF
--- a/examples/tags.js
+++ b/examples/tags.js
@@ -29,9 +29,9 @@ class Test extends React.Component {
     });
   };
 
-  toggleMaxTagCount = () => {
+  toggleMaxTagCount = (count) => {
     this.setState({
-      maxTagCount: this.state.maxTagCount ? null : 1,
+      maxTagCount: count,
     });
   };
 
@@ -58,7 +58,8 @@ class Test extends React.Component {
         </div>
         <p>
           <button onClick={this.toggleDisabled}>toggle disabled</button>
-          <button onClick={this.toggleMaxTagCount}>toggle maxTagCount (1)</button>
+          <button onClick={() => this.toggleMaxTagCount(0)}>toggle maxTagCount (0)</button>
+          <button onClick={() => this.toggleMaxTagCount(1)}>toggle maxTagCount (1)</button>
         </p>
       </div>
     );

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -1082,7 +1082,7 @@ export default class Select extends React.Component {
       let selectedValueNodes = [];
       let limitedCountValue = value;
       let maxTagPlaceholderEl;
-      if (maxTagCount && value.length > maxTagCount) {
+      if (maxTagCount !== undefined && value.length > maxTagCount) {
         limitedCountValue = limitedCountValue.slice(0, maxTagCount);
         const omittedValues = this.getVLForOnChange(value.slice(maxTagCount, value.length));
         let content = `+ ${value.length - maxTagCount} ...`;

--- a/tests/__snapshots__/Select.multiple.spec.js.snap
+++ b/tests/__snapshots__/Select.multiple.spec.js.snap
@@ -371,6 +371,58 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
 </div>
 `;
 
+exports[`Select.multiple render truncates tags by maxTagCount while maxTagCount is 0 1`] = `
+<div
+  class="rc-select rc-select-enabled"
+>
+  <div
+    aria-autocomplete="list"
+    aria-expanded="false"
+    aria-haspopup="true"
+    class="rc-select-selection
+            rc-select-selection--multiple"
+    role="combobox"
+  >
+    <div
+      class="rc-select-selection__rendered"
+    >
+      <ul>
+        <li
+          class="rc-select-selection__choice rc-select-selection__choice__disabled"
+          style="user-select:none;-webkit-user-select:none"
+          title="+ 3 ..."
+          unselectable="unselectable"
+        >
+          <div
+            class="rc-select-selection__choice__content"
+          >
+            + 3 ...
+          </div>
+        </li>
+        <li
+          class="rc-select-search rc-select-search--inline"
+        >
+          <div
+            class="rc-select-search__field__wrap"
+          >
+            <input
+              autocomplete="off"
+              class="rc-select-search__field"
+              value=""
+            />
+            <span
+              class="rc-select-search__field__mirror"
+            >
+               
+            </span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Select.multiple render truncates values by maxTagTextLength 1`] = `
 <div
   class="rc-select rc-select-enabled"

--- a/tests/__snapshots__/Select.tags.spec.js.snap
+++ b/tests/__snapshots__/Select.tags.spec.js.snap
@@ -708,6 +708,58 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
 </div>
 `;
 
+exports[`Select.tags render truncates tags by maxTagCount while maxTagCount is 0 1`] = `
+<div
+  class="rc-select rc-select-enabled"
+>
+  <div
+    aria-autocomplete="list"
+    aria-expanded="false"
+    aria-haspopup="true"
+    class="rc-select-selection
+            rc-select-selection--multiple"
+    role="combobox"
+  >
+    <div
+      class="rc-select-selection__rendered"
+    >
+      <ul>
+        <li
+          class="rc-select-selection__choice rc-select-selection__choice__disabled"
+          style="user-select:none;-webkit-user-select:none"
+          title="+ 3 ..."
+          unselectable="unselectable"
+        >
+          <div
+            class="rc-select-selection__choice__content"
+          >
+            + 3 ...
+          </div>
+        </li>
+        <li
+          class="rc-select-search rc-select-search--inline"
+        >
+          <div
+            class="rc-select-search__field__wrap"
+          >
+            <input
+              autocomplete="off"
+              class="rc-select-search__field"
+              value=""
+            />
+            <span
+              class="rc-select-search__field__mirror"
+            >
+               
+            </span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Select.tags render truncates values by maxTagTextLength 1`] = `
 <div
   class="rc-select rc-select-enabled"

--- a/tests/shared/renderTest.js
+++ b/tests/shared/renderTest.js
@@ -37,6 +37,22 @@ export default function maxTagTextLengthTest(mode) {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('truncates tags by maxTagCount while maxTagCount is 0', () => {
+      const wrapper = render(
+        <Select
+          {...{ [mode]: true } }
+          value={['one', 'two', 'three']}
+          maxTagCount={0}
+        >
+          <Option value="one">One</Option>
+          <Option value="two">Two</Option>
+          <Option value="three">Three</Option>
+        </Select>
+      );
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
     it('truncates tags by maxTagCount and show maxTagPlaceholder', () => {
       const wrapper = render(
         <Select
@@ -53,7 +69,6 @@ export default function maxTagTextLengthTest(mode) {
 
       expect(wrapper).toMatchSnapshot();
     });
-
 
     it('truncates tags by maxTagCount and show maxTagPlaceholder function', () => {
       const maxTagPlaceholder = (omittedValues) => {


### PR DESCRIPTION
allow maxTagCount to be 0, for some scenes like

![](https://user-images.githubusercontent.com/4323398/35181505-d6bacd2a-fdfd-11e7-9871-fce44ea79bf1.png)