### PR TITLE
Fix defaultFilter can not filter array children

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -142,7 +142,7 @@ export function defaultFilterFn(input, child) {
   if (child.props.disabled) {
     return false;
   }
-  const value = String(getPropValue(child, this.props.optionFilterProp));
+  const value = toArray(getPropValue(child, this.props.optionFilterProp)).join('');
   return (
     value.toLowerCase().indexOf(input.toLowerCase()) > -1
   );

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -190,6 +190,20 @@ describe('Select', () => {
     expect(wrapper.find('MenuItem').props().value).toBe('2');
   });
 
+  it('filter array children', () => {
+    const wrapper = mount(
+      <Select optionFilterProp="children">
+        <Option value="1" label="One">One{1}</Option>
+        <Option value="2" label="Two">Two{2}</Option>
+      </Select>
+    );
+
+    wrapper.find('input').simulate('change', { target: { value: 'Two2' } });
+
+    expect(wrapper.find('MenuItem').length).toBe(1);
+    expect(wrapper.find('MenuItem').props().value).toBe('2');
+  });
+
   it('no search', () => {
     const wrapper = render(
       <Select showSearch={false} value="1">


### PR DESCRIPTION
The default filter works not properly when children is an array.