### PR TITLE
refactoring: update state.value format

### DIFF
--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -47,7 +47,6 @@ class Test extends React.Component {
     };
     return (
       <div>
-        <Select tags />
         <h2>multiple select（scroll the menu）</h2>
 
         <p>

--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -47,6 +47,7 @@ class Test extends React.Component {
     };
     return (
       <div>
+        <Select tags />
         <h2>multiple select（scroll the menu）</h2>
 
         <p>

--- a/examples/optgroup.js
+++ b/examples/optgroup.js
@@ -5,8 +5,8 @@ import Select, { Option, OptGroup } from 'rc-select';
 import 'rc-select/assets/index.less';
 import ReactDOM from 'react-dom';
 
-function onChange(value) {
-  console.log(`selected ${value}`);
+function onChange(value, option) {
+  console.log(`selected ${value}`, option);
 }
 
 const c1 = (
@@ -21,7 +21,7 @@ const c1 = (
         onChange={onChange}
       >
         <OptGroup label="manager">
-          <Option value="jack">
+          <Option value="jack" test-prop="jack-prop">
             <b
               style={{
                 color: 'red',
@@ -30,10 +30,10 @@ const c1 = (
               jack
             </b>
           </Option>
-          <Option value="lucy">lucy</Option>
+          <Option value="lucy" test-prop="lucy-prop">lucy</Option>
         </OptGroup>
         <OptGroup label="engineer">
-          <Option value="yiminghe">yiminghe</Option>
+          <Option value="yiminghe" test-prop="yiminghe-prop">yiminghe</Option>
         </OptGroup>
       </Select>
     </div>

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -83,6 +83,7 @@ export default class DropdownMenu extends React.Component {
       onMenuSelect,
       inputValue,
       firstActiveValue,
+      backfillValue,
     } = props;
     if (menuItems && menuItems.length) {
       const menuProps = {};
@@ -132,7 +133,7 @@ export default class DropdownMenu extends React.Component {
 
       // clear activeKey when inputValue change
       const lastValue = value && value[value.length - 1];
-      if (inputValue !== this.lastInputValue && (!lastValue || !lastValue.backfill)) {
+      if (inputValue !== this.lastInputValue && (!lastValue || lastValue !== backfillValue)) {
         activeKeyProps.activeKey = '';
       }
 

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -25,7 +25,7 @@ import {
   findFirstMenuItem,
   includesSeparators,
   splitBySeparators,
-  findIndexInValueByLabel,
+  findIndexInValueByValue,
   defaultFilterFn,
   validateOptionValue,
   saveRef,
@@ -164,7 +164,9 @@ export default class Select extends React.Component {
       includesSeparators(val, tokenSeparators)
     ) {
       const nextValue = this.getValueByInput(val);
-      this.fireChange(nextValue);
+      if (nextValue !== undefined) {
+        this.fireChange(nextValue);
+      }
       this.setOpenState(false, true);
       this.setInputValue('', false);
       return;
@@ -359,7 +361,9 @@ export default class Select extends React.Component {
         this.state.inputValue = this.getInputDOMNode().value = '';
 
         value = this.getValueByInput(inputValue);
-        this.fireChange(value);
+        if (value !== undefined) {
+          this.fireChange(value);
+        }
       }
       props.onBlur(this.getVLForOnChange(value));
       this.setOpenState(false);
@@ -642,21 +646,26 @@ export default class Select extends React.Component {
   getValueByInput = string => {
     const { multiple, tokenSeparators } = this.props;
     let nextValue = this.state.value;
+    let hasNewValue = false;
     splitBySeparators(string, tokenSeparators).forEach(label => {
       const selectedValue = [label];
-      if (findIndexInValueByLabel(nextValue, label) === -1) {
-        if (multiple) {
-          const value = this.getValueByLabel(label);
-          if (value) {
-            nextValue = nextValue.concat(value);
-          }
-        } else {
+      if (multiple) {
+        const value = this.getValueByLabel(label);
+        if (value && findIndexInValueByValue(nextValue, value) === -1) {
+          nextValue = nextValue.concat(value);
+          hasNewValue = true;
+          this.fireSelect(value);
+        }
+      } else {
+        // tag
+        if (findIndexInValueByValue(nextValue, label) === -1) {
           nextValue = nextValue.concat(selectedValue);
+          hasNewValue = true;
+          this.fireSelect(label);
         }
       }
-      this.fireSelect(label);
     });
-    return nextValue;
+    return hasNewValue ? nextValue : undefined;
   };
 
   focus() {

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -529,7 +529,7 @@ export default class Select extends React.Component {
     if (state.value.length) {
       hidden = true;
     }
-    if (isCombobox(props) && state.value.length === 1 && !state.value[0].key) {
+    if (isCombobox(props) && state.value.length === 1 && !state.value[0]) {
       hidden = false;
     }
     const placeholder = props.placeholder;

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -434,7 +434,7 @@ export default class Select extends React.Component {
     };
     optionsInfo = optionsInfo || this.state.optionsInfo;
     if (optionsInfo.has(value)) {
-      return optionsInfo.get(value);
+      return optionsInfo.get(value) || defaultInfo;
     }
     return defaultInfo;
   }

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -612,6 +612,7 @@ export default class Select extends React.Component {
     }
     const nextState = {
       open,
+      backfillValue: undefined,
     };
     // clear search input value when open is false in singleMode.
     if (!open && isSingleMode(props) && props.showSearch) {
@@ -694,7 +695,7 @@ export default class Select extends React.Component {
   filterOption = (input, child, defaultFilter = defaultFilterFn) => {
     const { value } = this.state;
     const lastValue = value[value.length - 1];
-    if (!input || (lastValue && lastValue.backfill)) {
+    if (!input || (lastValue && lastValue === this.state.backfillValue)) {
       return true;
     }
     let filterFn = this.props.filterOption;
@@ -1237,6 +1238,7 @@ export default class Select extends React.Component {
         visible={open}
         inputValue={state.inputValue}
         value={state.value}
+        backfillValue={state.backfillValue}
         firstActiveValue={props.firstActiveValue}
         onDropdownVisibleChange={this.onDropdownVisibleChange}
         getPopupContainer={props.getPopupContainer}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -78,32 +78,23 @@ export default class Select extends React.Component {
 
   constructor(props) {
     super(props);
-    let value = [];
-    if ('value' in props) {
-      value = toArray(props.value);
-    } else {
-      value = toArray(props.defaultValue);
-    }
-    value = this.addLabelToValue(props, value);
-    value = this.addTitleToValue(props, value);
+    const value = this.getValueStateFromProps(props);
+    const optionsInfo = this.getOptionsInfoFromProps(props);
     let inputValue = '';
     if (props.combobox) {
       inputValue = value.length
-        ? this.getLabelFromProps(props, value[0].key)
+        ? this.getLabelByValue(value[0], optionsInfo)
         : '';
     }
     let open = props.open;
     if (open === undefined) {
       open = props.defaultOpen;
     }
-    this._valueOptions = [];
-    if (value.length > 0) {
-      this._valueOptions = this.getOptionsByValue(value);
-    }
     this.state = {
       value,
       inputValue,
       open,
+      optionsInfo,
     };
     this.adjustOpenState();
   }
@@ -115,17 +106,19 @@ export default class Select extends React.Component {
   }
 
   componentWillReceiveProps = nextProps => {
+    const optionsInfo = this.getOptionsInfoFromProps(nextProps);
+    this.setState({
+      optionsInfo,
+    });
     if ('value' in nextProps) {
-      let value = toArray(nextProps.value);
-      value = this.addLabelToValue(nextProps, value);
-      value = this.addTitleToValue(nextProps, value);
+      const value = this.getValueStateFromProps(nextProps);
       this.setState({
         value,
       });
       if (nextProps.combobox) {
         this.setState({
           inputValue: value.length
-            ? this.getLabelFromProps(nextProps, value[0].key)
+            ? this.getLabelByValue(value[0], optionsInfo)
             : '',
         });
       }
@@ -181,11 +174,7 @@ export default class Select extends React.Component {
       open: true,
     });
     if (isCombobox(this.props)) {
-      this.fireChange([
-        {
-          key: val,
-        },
-      ]);
+      this.fireChange([val]);
     }
   };
 
@@ -229,7 +218,7 @@ export default class Select extends React.Component {
       event.preventDefault();
       const { value } = state;
       if (value.length) {
-        this.removeSelected(value[value.length - 1].key);
+        this.removeSelected(value[value.length - 1]);
       }
       return;
     }
@@ -262,24 +251,13 @@ export default class Select extends React.Component {
     let value = this.state.value;
     const props = this.props;
     const selectedValue = getValuePropValue(item);
-    const selectedLabel = this.getLabelFromOption(item);
     const lastValue = value[value.length - 1];
-    this.fireSelect({
-      key: selectedValue,
-      label: selectedLabel,
-    });
-    const selectedTitle = item.props.title;
+    this.fireSelect(selectedValue);
     if (isMultipleOrTags(props)) {
       if (findIndexInValueByKey(value, selectedValue) !== -1) {
         return;
       }
-      value = value.concat([
-        {
-          key: selectedValue,
-          label: selectedLabel,
-          title: selectedTitle,
-        },
-      ]);
+      value = value.concat([selectedValue]);
     } else {
       if (isCombobox(props)) {
         this.skipAdjustOpen = true;
@@ -288,17 +266,11 @@ export default class Select extends React.Component {
           this.skipAdjustOpen = false;
         }, 0);
       }
-      if (lastValue && lastValue.key === selectedValue && !lastValue.backfill) {
+      if (lastValue && lastValue === selectedValue && selectedValue !== this.state.backfillValue) {
         this.setOpenState(false, true);
         return;
       }
-      value = [
-        {
-          key: selectedValue,
-          label: selectedLabel,
-          title: selectedTitle,
-        },
-      ];
+      value = [selectedValue];
       this.setOpenState(false, true);
     }
     this.fireChange(value);
@@ -378,12 +350,7 @@ export default class Select extends React.Component {
         if (options.length) {
           const firstOption = findFirstMenuItem(options);
           if (firstOption) {
-            value = [
-              {
-                key: firstOption.key,
-                label: this.getLabelFromOption(firstOption),
-              },
-            ];
+            value = [firstOption.key];
             this.fireChange(value);
           }
         }
@@ -422,11 +389,77 @@ export default class Select extends React.Component {
     this.selectTriggerRef.triggerRef.forcePopupAlign();
   };
 
-  getOptionsFromChildren = (value, children, options = []) => {
-    let values = value;
-    if (!Array.isArray(value)) {
-      values = [value];
+  getValueStateFromProps = props => {
+    let value = [];
+    if ('value' in props) {
+      value = toArray(props.value);
+    } else {
+      value = toArray(props.defaultValue);
     }
+    if (props.labelInValue) {
+      value = value.map((v) => {
+        return v.key;
+      });
+    }
+    return value;
+  }
+
+  getOptionInfoByValue = (value, optionsInfo) => {
+    let ret = {
+      option: <Option value={value} key={value}>{value}</Option>,
+      value,
+      label: value,
+    };
+    optionsInfo = optionsInfo || this.state.optionsInfo;
+    for (let i = 0; i < optionsInfo.length; i++) {
+      if (optionsInfo[i].value === value) {
+        ret = optionsInfo[i];
+        break;
+      }
+    }
+    return ret;
+  }
+
+  getOptionsInfoFromProps = props => {
+    const options = this.getOptionsFromChildren(props.children);
+    const oldOptionsInfo = this.state ? this.state.optionsInfo : [];
+    const value = this.state ? this.state.value : [];
+    const valueInNewOptionsFlag = {};
+    const optionsInfo = options.map((option) => {
+      const singleValue = getValuePropValue(option);
+      valueInNewOptionsFlag[singleValue] = true;
+      return {
+        option,
+        value: singleValue,
+        label: this.getLabelFromOption(option),
+        title: option.props.title,
+      };
+    });
+    value.forEach(v => {
+      if (valueInNewOptionsFlag[v] === undefined) {
+        const index = oldOptionsInfo.findIndex(info => {
+          return v === info.value;
+        });
+        if (index !== -1) {
+          optionsInfo.push(oldOptionsInfo[index]);
+        }
+      }
+    });
+    return optionsInfo;
+  }
+
+  getOptionByValue = value => {
+    const info = this.getOptionInfoByValue(value);
+    return info.option;
+  }
+
+  getOptionsByValue = values => {
+    return values.map(value => {
+      return this.getOptionByValue(value);
+    });
+  }
+
+  getOptionsFromChildren = (children, options = []) => {
     React.Children.forEach(children, child => {
       if (!child) {
         return;
@@ -434,118 +467,58 @@ export default class Select extends React.Component {
       if (child.type.isSelectOptGroup) {
         this.getOptionsFromChildren(child.props.children, options);
       } else {
-        const index = findIndexInValueByKey(values, getValuePropValue(child));
-        if (index !== -1) {
-          options[index] = child;
-        }
+        options.push(child);
       }
     });
-    values.forEach((v, i) => {
-      if (!options[i]) {
-        for (let j = 0; j < this._valueOptions.length; j++) {
-          const item = this._valueOptions[j];
-          if (getValuePropValue(item) === v.key) {
-            options[i] = item;
-            break;
-          }
-        }
-        if (!options[i]) {
-          options[i] = <Option value={v.key} key={v.key}>{v.label}</Option>;
-        }
-      }
-    });
-    if (!Array.isArray(value)) {
-      return options[0];
-    }
     return options;
   };
 
-  getSingleOptionByValueKey = (key) => {
-    return this.getOptionsFromChildren({
-      key,
-      label: key,
-    }, this.props.children);
-  };
-
-  getOptionsByValue = (value) => {
-    if (value === undefined) {
-      return undefined;
-    }
-    if (value.length === 0) {
-      return [];
-    }
-    return this.getOptionsFromChildren(value, this.props.children);
-  };
-
-  getLabelBySingleValue = (children, value) => {
-    if (value === undefined) {
-      return null;
-    }
-    let label = null;
-    React.Children.forEach(children, child => {
-      if (!child) {
-        return;
-      }
-      if (child.type.isSelectOptGroup) {
-        const maybe = this.getLabelBySingleValue(child.props.children, value);
-        if (maybe !== null) {
-          label = maybe;
-        }
-      } else if (getValuePropValue(child) === value) {
-        label = this.getLabelFromOption(child);
-      }
-    });
-    return label;
-  };
-
-  getValueByLabel = (children, label) => {
+  getValueByLabel = (label) => {
     if (label === undefined) {
       return null;
     }
     let value = null;
-    React.Children.forEach(children, child => {
-      if (!child) {
-        return;
-      }
-      if (child.type.isSelectOptGroup) {
-        const maybe = this.getValueByLabel(child.props.children, label);
-        if (maybe !== null) {
-          value = maybe;
-        }
-      } else if (toArray(this.getLabelFromOption(child)).join('') === label) {
-        value = getValuePropValue(child);
+    this.state.optionsInfo.forEach(info => {
+      if (toArray(info.label).join('') === label) {
+        value = info.value;
       }
     });
     return value;
   };
 
-  getLabelFromOption = child => {
-    return getPropValue(child, this.props.optionLabelProp);
+  getLabelFromOption = option => {
+    return getPropValue(option, this.props.optionLabelProp);
   };
 
-  getLabelFromProps = (props, value) => {
-    return this.getLabelByValue(props.children, value);
-  };
+  getVLByValue = value => {
+    if (this.props.labelInValue) {
+      return {
+        key: value,
+        label: this.getLabelByValue(value),
+      };
+    }
+    return value;
+  }
 
   getVLForOnChange = vls_ => {
     let vls = vls_;
     if (vls !== undefined) {
       if (!this.props.labelInValue) {
-        vls = vls.map(v => v.key);
+        vls = vls.map(v => v);
       } else {
-        vls = vls.map(vl => ({ key: vl.key, label: vl.label }));
+        vls = vls.map(vl => ({
+          key: vl,
+          label: this.getLabelByValue(vl),
+        }));
       }
       return isMultipleOrTags(this.props) ? vls : vls[0];
     }
     return vls;
   };
 
-  getLabelByValue = (children, value) => {
-    const label = this.getLabelBySingleValue(children, value);
-    if (label === null) {
-      return value;
-    }
-    return label;
+  getLabelByValue = (value, optionsInfo) => {
+    const info = this.getOptionInfoByValue(value, optionsInfo);
+    return info.label;
   };
 
   getDropdownContainer = () => {
@@ -675,25 +648,21 @@ export default class Select extends React.Component {
   };
 
   getValueByInput = string => {
-    const { multiple, tokenSeparators, children } = this.props;
+    const { multiple, tokenSeparators } = this.props;
     let nextValue = this.state.value;
     splitBySeparators(string, tokenSeparators).forEach(label => {
-      const selectedValue = { key: label, label };
+      const selectedValue = [label];
       if (findIndexInValueByLabel(nextValue, label) === -1) {
         if (multiple) {
-          const value = this.getValueByLabel(children, label);
+          const value = this.getValueByLabel(label);
           if (value) {
-            selectedValue.key = value;
-            nextValue = nextValue.concat(selectedValue);
+            nextValue = nextValue.concat(value);
           }
         } else {
           nextValue = nextValue.concat(selectedValue);
         }
       }
-      this.fireSelect({
-        key: label,
-        label,
-      });
+      this.fireSelect(label);
     });
     return nextValue;
   };
@@ -720,19 +689,14 @@ export default class Select extends React.Component {
     }
 
     const key = getValuePropValue(item);
-    const label = this.getLabelFromOption(item);
-    const backfillValue = {
-      key,
-      label,
-      backfill: true,
-    };
 
     if (isCombobox(this.props)) {
       this.setInputValue(key, false);
     }
 
     this.setState({
-      value: [backfillValue],
+      value: [key],
+      backfillValue: key,
     });
   };
 
@@ -819,54 +783,13 @@ export default class Select extends React.Component {
     }
   };
 
-  addLabelToValue = (props, value_) => {
-    let value = value_;
-    if (props.labelInValue) {
-      value.forEach(v => {
-        v.label = v.label || this.getLabelFromProps(props, v.key);
-      });
-    } else {
-      value = value.map(v => {
-        return {
-          key: v,
-          label: this.getLabelFromProps(props, v),
-        };
-      });
-    }
-    return value;
-  };
-
-  addTitleToValue = (props, values) => {
-    let nextValues = values;
-    const keys = values.map(v => v.key);
-    React.Children.forEach(props.children, child => {
-      if (!child) {
-        return;
-      }
-      if (child.type.isSelectOptGroup) {
-        nextValues = this.addTitleToValue(child.props, nextValues);
-      } else {
-        const value = getValuePropValue(child);
-        const valueIndex = keys.indexOf(value);
-        if (valueIndex > -1) {
-          nextValues[valueIndex].title = child.props.title;
-        }
-      }
-    });
-    return nextValues;
-  };
-
   removeSelected = selectedKey => {
     const props = this.props;
     if (props.disabled || this.isChildDisabled(selectedKey)) {
       return;
     }
-    let label;
     const value = this.state.value.filter(singleValue => {
-      if (singleValue.key === selectedKey) {
-        label = singleValue.label;
-      }
-      return singleValue.key !== selectedKey;
+      return singleValue !== selectedKey;
     });
     const canMultiple = isMultipleOrTags(props);
 
@@ -875,10 +798,10 @@ export default class Select extends React.Component {
       if (props.labelInValue) {
         event = {
           key: selectedKey,
-          label,
+          label: this.getLabelByValue(selectedKey),
         };
       }
-      props.onDeselect(event, this.getSingleOptionByValueKey(selectedKey));
+      props.onDeselect(event, this.getOptionByValue(selectedKey));
     }
     this.fireChange(value);
   };
@@ -891,8 +814,7 @@ export default class Select extends React.Component {
   };
 
   fireSelect = value => {
-    const { labelInValue, onSelect } = this.props;
-    onSelect(labelInValue ? value : value.key, this.getSingleOptionByValueKey(value.key));
+    this.props.onSelect(this.getVLByValue(value), this.getOptionByValue(value));
   };
 
   fireChange = value => {
@@ -904,7 +826,6 @@ export default class Select extends React.Component {
     }
     const vls = this.getVLForOnChange(value);
     const options = this.getOptionsByValue(value);
-    this._valueOptions = options;
     props.onChange(vls, isMultipleOrTags(this.props) ? options : options[0]);
   };
 
@@ -956,13 +877,13 @@ export default class Select extends React.Component {
       let value = this.state.value || [];
       value = value.filter(singleValue => {
         return (
-          childrenKeys.indexOf(singleValue.key) === -1 &&
+          childrenKeys.indexOf(singleValue) === -1 &&
           (!inputValue ||
-            String(singleValue.key).indexOf(String(inputValue)) > -1)
+            String(singleValue).indexOf(String(inputValue)) > -1)
         );
       });
       value.forEach(singleValue => {
-        const key = singleValue.key;
+        const key = singleValue;
         const menuItem = (
           <MenuItem
             style={UNSELECTABLE_STYLE}
@@ -1121,17 +1042,18 @@ export default class Select extends React.Component {
           }
         }
         const singleValue = value[0];
+        const info = this.getOptionInfoByValue(singleValue);
         selectedValue = (
           <div
             key="value"
             className={`${prefixCls}-selection-selected-value`}
-            title={singleValue.title || singleValue.label}
+            title={info.title || info.label}
             style={{
               display: showSelectedValue ? 'block' : 'none',
               opacity,
             }}
           >
-            {value[0].label}
+            {info.label}
           </div>
         );
       }
@@ -1176,8 +1098,9 @@ export default class Select extends React.Component {
       }
       if (isMultipleOrTags(props)) {
         selectedValueNodes = limitedCountValue.map(singleValue => {
-          let content = singleValue.label;
-          const title = singleValue.title || content;
+          const info = this.getOptionInfoByValue(singleValue);
+          let content = info.label;
+          const title = info.title || content;
           if (
             maxTagTextLength &&
             typeof content === 'string' &&
@@ -1185,7 +1108,7 @@ export default class Select extends React.Component {
           ) {
             content = `${content.slice(0, maxTagTextLength)}...`;
           }
-          const disabled = this.isChildDisabled(singleValue.key);
+          const disabled = this.isChildDisabled(singleValue);
           const choiceClassName = disabled
             ? `${prefixCls}-selection__choice ${prefixCls}-selection__choice__disabled`
             : `${prefixCls}-selection__choice`;
@@ -1195,7 +1118,7 @@ export default class Select extends React.Component {
               {...UNSELECTABLE_ATTRIBUTE}
               onMouseDown={preventDefaultEvent}
               className={choiceClassName}
-              key={singleValue.key}
+              key={singleValue}
               title={title}
             >
               <div className={`${prefixCls}-selection__choice__content`}>
@@ -1204,7 +1127,7 @@ export default class Select extends React.Component {
               {disabled ? null : (
                 <span
                   className={`${prefixCls}-selection__choice__remove`}
-                  onClick={this.removeSelected.bind(this, singleValue.key)}
+                  onClick={this.removeSelected.bind(this, singleValue)}
                 />)}
             </li>
           );

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -18,6 +18,7 @@ import {
   isMultipleOrTagsOrCombobox,
   isSingleMode,
   toArray,
+  getMapKey,
   findIndexInValueBySingleValue,
   getLabelFromPropsValue,
   UNSELECTABLE_ATTRIBUTE,
@@ -410,21 +411,22 @@ export default class Select extends React.Component {
 
   getOptionsInfoFromProps = props => {
     const options = this.getOptionsFromChildren(props.children);
-    const oldOptionsInfo = this.state ? this.state.optionsInfo : new Map();
+    const oldOptionsInfo = this.state ? this.state.optionsInfo : {};
     const value = this.state ? this.state.value : [];
-    const optionsInfo = new Map();
+    const optionsInfo = {};
     options.forEach((option) => {
       const singleValue = getValuePropValue(option);
-      optionsInfo.set(singleValue, {
+      optionsInfo[getMapKey(singleValue)] = {
         option,
         value: singleValue,
         label: this.getLabelFromOption(option),
         title: option.props.title,
-      });
+      };
     });
     value.forEach(v => {
-      if (!optionsInfo.has(v)) {
-        optionsInfo.set(v, oldOptionsInfo.get(v));
+      const key = getMapKey(v);
+      if (!optionsInfo[key]) {
+        optionsInfo[key] = oldOptionsInfo[key];
       }
     });
     return optionsInfo;
@@ -433,8 +435,8 @@ export default class Select extends React.Component {
   getOptionInfoBySingleValue = (value, optionsInfo) => {
     let info;
     optionsInfo = optionsInfo || this.state.optionsInfo;
-    if (optionsInfo.has(value)) {
-      info = optionsInfo.get(value);
+    if (optionsInfo[getMapKey(value)]) {
+      info = optionsInfo[getMapKey(value)];
     }
     if (info) {
       return info;
@@ -484,7 +486,8 @@ export default class Select extends React.Component {
       return null;
     }
     let value = null;
-    this.state.optionsInfo.forEach(info => {
+    Object.keys(this.state.optionsInfo).forEach(key => {
+      const info = this.state.optionsInfo[key];
       if (toArray(info.label).join('') === label) {
         value = info.value;
       }

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -85,6 +85,7 @@ export default class SelectTrigger extends React.Component {
         onMenuDeselect={props.onMenuDeselect}
         onPopupScroll={props.onPopupScroll}
         value={props.value}
+        backfillValue={props.backfillValue}
         firstActiveValue={props.firstActiveValue}
         defaultActiveFirstOption={props.defaultActiveFirstOption}
         dropdownMenuStyle={props.dropdownMenuStyle}

--- a/src/util.js
+++ b/src/util.js
@@ -57,18 +57,7 @@ export function preventDefaultEvent(e) {
   e.preventDefault();
 }
 
-export function findIndexInValueByKey(value, key) {
-  let index = -1;
-  for (let i = 0; i < value.length; i++) {
-    if (value[i] === key) {
-      index = i;
-      break;
-    }
-  }
-  return index;
-}
-
-export function findIndexInValueByValue(value, singleValue) {
+export function findIndexInValueBySingleValue(value, singleValue) {
   let index = -1;
   for (let i = 0; i < value.length; i++) {
     if (value[i] === singleValue) {
@@ -77,6 +66,18 @@ export function findIndexInValueByValue(value, singleValue) {
     }
   }
   return index;
+}
+
+export function getLabelFromPropsValue(value, key) {
+  let label;
+  value = toArray(value);
+  for (let i = 0; i < value.length; i++) {
+    if (value[i].key === key) {
+      label = value[i].label;
+      break;
+    }
+  }
+  return label;
 }
 
 export function getSelectKeys(menuItems, value) {
@@ -92,7 +93,7 @@ export function getSelectKeys(menuItems, value) {
     } else {
       const itemValue = getValuePropValue(item);
       const itemKey = item.key;
-      if (findIndexInValueByKey(value, itemValue) !== -1 && itemKey) {
+      if (findIndexInValueBySingleValue(value, itemValue) !== -1 && itemKey) {
         selectedKeys.push(itemKey);
       }
     }

--- a/src/util.js
+++ b/src/util.js
@@ -53,6 +53,10 @@ export function toArray(value) {
   return ret;
 }
 
+export function getMapKey(value) {
+  return `${typeof value}-${value}`;
+}
+
 export function preventDefaultEvent(e) {
   e.preventDefault();
 }

--- a/src/util.js
+++ b/src/util.js
@@ -60,7 +60,7 @@ export function preventDefaultEvent(e) {
 export function findIndexInValueByKey(value, key) {
   let index = -1;
   for (let i = 0; i < value.length; i++) {
-    if (value[i].key === key) {
+    if (value[i] === key) {
       index = i;
       break;
     }
@@ -71,7 +71,7 @@ export function findIndexInValueByKey(value, key) {
 export function findIndexInValueByLabel(value, label) {
   let index = -1;
   for (let i = 0; i < value.length; i++) {
-    if (toArray(value[i].label).join('') === label) {
+    if (toArray(value[i]).join('') === label) {
       index = i;
       break;
     }

--- a/src/util.js
+++ b/src/util.js
@@ -68,10 +68,10 @@ export function findIndexInValueByKey(value, key) {
   return index;
 }
 
-export function findIndexInValueByLabel(value, label) {
+export function findIndexInValueByValue(value, singleValue) {
   let index = -1;
   for (let i = 0; i < value.length; i++) {
-    if (toArray(value[i]).join('') === label) {
+    if (value[i] === singleValue) {
       index = i;
       break;
     }

--- a/tests/DropdownMenu.spec.js
+++ b/tests/DropdownMenu.spec.js
@@ -18,7 +18,7 @@ describe('DropdownMenu', () => {
     const wrapper = render(
       <DropdownMenu
         menuItems={menuItems}
-        value={[{ key: '1' }]}
+        value={['1']}
       />
     );
 
@@ -34,7 +34,7 @@ describe('DropdownMenu', () => {
     const wrapper = mount(
       <DropdownMenu
         menuItems={menuItems}
-        value={[{ key: '1' }]}
+        value={['1']}
       />
     );
 
@@ -50,7 +50,7 @@ describe('DropdownMenu', () => {
     const wrapper = mount(
       <DropdownMenu
         menuItems={menuItems}
-        value={[{ key: '1' }]}
+        value={['1']}
       />
     );
 
@@ -105,7 +105,7 @@ describe('DropdownMenu', () => {
 
     const wrapper = mount(
       <DropdownMenu
-        value={[{ key: '1' }]}
+        value={['1']}
         menuItems={menuItems}
         firstActiveValue={'2'}
       />

--- a/tests/Select.combobox.spec.js
+++ b/tests/Select.combobox.spec.js
@@ -246,6 +246,7 @@ describe('Select.combobox', () => {
     expect(wrapper.state().value).toEqual(['Two']);
     expect(wrapper.state().backfillValue).toEqual('Two');
     expect(wrapper.state().inputValue).toBe('Two');
+    expect(wrapper.find('MenuItem').at(1).text()).toBe('Two');
     expect(handleChange).not.toBeCalled();
     expect(handleSelect).not.toBeCalled();
 

--- a/tests/Select.combobox.spec.js
+++ b/tests/Select.combobox.spec.js
@@ -34,6 +34,31 @@ describe('Select.combobox', () => {
     );
 
     expect(wrapper.state().inputValue).toBe('1');
+    expect(
+      wrapper.find('.rc-select-selection__placeholder').prop('style')
+    ).toHaveProperty('display', 'none');
+  });
+
+  it.only('placeholder', () => {
+    const wrapper = mount(
+      <Select combobox placeholder="placeholder">
+        <Option value="1">1</Option>
+        <Option value="2">2</Option>
+      </Select>
+    );
+
+    expect(wrapper.state().inputValue).toBe('');
+    expect(
+      wrapper.find('.rc-select-selection__placeholder').text()
+    ).toBe('placeholder');
+    expect(
+      wrapper.find('.rc-select-selection__placeholder').prop('style')
+    ).toHaveProperty('display', 'block');
+    wrapper.find('input').simulate('change', { target: { value: '1' } });
+    expect(
+      wrapper.update().find('.rc-select-selection__placeholder').prop('style')
+    ).toHaveProperty('display', 'none');
+    expect(wrapper.state().inputValue).toBe('1');
   });
 
   it('fire change event immediately when user inputing', () => {

--- a/tests/Select.combobox.spec.js
+++ b/tests/Select.combobox.spec.js
@@ -47,7 +47,7 @@ describe('Select.combobox', () => {
 
     wrapper.find('input').simulate('change', { target: { value: '1' } });
 
-    expect(handleChange).toBeCalledWith('1', <Option key="1" value="1" />);
+    expect(handleChange).toBeCalledWith('1', <Option key="1" value="1">1</Option>);
   });
 
   it('set inputValue when user select a option', () => {
@@ -221,25 +221,15 @@ describe('Select.combobox', () => {
 
     input.simulate('keyDown', { keyCode: KeyCode.DOWN });
 
-    expect(wrapper.state().value).toEqual([
-      {
-        key: 'Two',
-        label: 'Two',
-        backfill: true,
-      },
-    ]);
+    expect(wrapper.state().value).toEqual(['Two']);
+    expect(wrapper.state().backfillValue).toEqual('Two');
     expect(wrapper.state().inputValue).toBe('Two');
     expect(handleChange).not.toBeCalled();
     expect(handleSelect).not.toBeCalled();
 
     input.simulate('keyDown', { keyCode: KeyCode.ENTER });
 
-    expect(wrapper.state().value).toEqual([
-      {
-        key: 'Two',
-        label: 'Two',
-      },
-    ]);
+    expect(wrapper.state().value).toEqual(['Two']);
     expect(handleChange).toBeCalledWith('Two', <Option value="Two">Two</Option>);
     expect(handleSelect).toBeCalledWith('Two', <Option value="Two">Two</Option>);
   });

--- a/tests/Select.combobox.spec.js
+++ b/tests/Select.combobox.spec.js
@@ -34,12 +34,9 @@ describe('Select.combobox', () => {
     );
 
     expect(wrapper.state().inputValue).toBe('1');
-    expect(
-      wrapper.find('.rc-select-selection__placeholder').prop('style')
-    ).toHaveProperty('display', 'none');
   });
 
-  it.only('placeholder', () => {
+  it('placeholder', () => {
     const wrapper = mount(
       <Select combobox placeholder="placeholder">
         <Option value="1">1</Option>
@@ -257,6 +254,28 @@ describe('Select.combobox', () => {
     expect(wrapper.state().value).toEqual(['Two']);
     expect(handleChange).toBeCalledWith('Two', <Option value="Two">Two</Option>);
     expect(handleSelect).toBeCalledWith('Two', <Option value="Two">Two</Option>);
+  });
+
+  it('should hide clear icon when value is \'\'', () => {
+    const wrapper = mount(
+      <Select combobox value="" allowClear>
+        <Option value="One">One</Option>
+        <Option value="Two">Two</Option>
+      </Select>
+    );
+
+    expect(wrapper.find('.rc-select-selection__clear').length).toBe(0);
+  });
+
+  it('should show clear icon when inputValue is not \'\'', () => {
+    const wrapper = mount(
+      <Select combobox value="One" allowClear>
+        <Option value="One">One</Option>
+        <Option value="Two">Two</Option>
+      </Select>
+    );
+
+    expect(wrapper.find('.rc-select-selection__clear').length).toBe(1);
   });
 
   it('should hide clear icon when inputValue is \'\'', () => {

--- a/tests/Select.multiple.spec.js
+++ b/tests/Select.multiple.spec.js
@@ -50,11 +50,8 @@ describe('Select.multiple', () => {
 
     expect(handleChange).toBeCalledWith(['1', '2'], expect.anything());
     expect(wrapper.state().value).toEqual(['1', '2']);
-    // TODO
-    // expect(wrapper.state().value).toEqual([
-    //   { key: '1', label: 'One' },
-    //   { key: '2', label: 'Two' },
-    // ]);
+    expect(wrapper.find('.rc-select-selection__choice__content').at(0).text()).toEqual('One');
+    expect(wrapper.find('.rc-select-selection__choice__content').at(1).text()).toEqual('Two');
     expect(wrapper.state().inputValue).toBe('');
     expect(wrapper.state().open).toBe(false);
     expect(input.instance().focus).toBeCalled();

--- a/tests/Select.multiple.spec.js
+++ b/tests/Select.multiple.spec.js
@@ -49,10 +49,12 @@ describe('Select.multiple', () => {
     } });
 
     expect(handleChange).toBeCalledWith(['1', '2'], expect.anything());
-    expect(wrapper.state().value).toEqual([
-      { key: '1', label: 'One' },
-      { key: '2', label: 'Two' },
-    ]);
+    expect(wrapper.state().value).toEqual(['1', '2']);
+    // TODO
+    // expect(wrapper.state().value).toEqual([
+    //   { key: '1', label: 'One' },
+    //   { key: '2', label: 'Two' },
+    // ]);
     expect(wrapper.state().inputValue).toBe('');
     expect(wrapper.state().open).toBe(false);
     expect(input.instance().focus).toBeCalled();

--- a/tests/Select.multiple.spec.js
+++ b/tests/Select.multiple.spec.js
@@ -21,12 +21,14 @@ describe('Select.multiple', () => {
 
   it('tokenize input', () => {
     const handleChange = jest.fn();
+    const handleSelect = jest.fn();
     const wrapper = mount(
       <Select
         multiple
         optionLabelProp="children"
         tokenSeparators={[',']}
         onChange={handleChange}
+        onSelect={handleSelect}
       >
         <OptGroup key="group1">
           <Option value="1">One</Option>
@@ -48,7 +50,13 @@ describe('Select.multiple', () => {
       value: 'One,Two,Three',
     } });
 
+    input.simulate('change', { target: {
+      value: 'One,Two',
+    } });
+
     expect(handleChange).toBeCalledWith(['1', '2'], expect.anything());
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledTimes(2);
     expect(wrapper.state().value).toEqual(['1', '2']);
     expect(wrapper.find('.rc-select-selection__choice__content').at(0).text()).toEqual('One');
     expect(wrapper.find('.rc-select-selection__choice__content').at(1).text()).toEqual('Two');

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -60,7 +60,9 @@ describe('Select', () => {
         </OptGroup>
       </Select>
     );
-    expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: '一' }]);
+    expect(wrapper.state().value).toEqual(['1']);
+    // TODO checkout title
+    // expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: '一' }]);
   });
 
   it('convert defaultValue to array', () => {
@@ -71,7 +73,9 @@ describe('Select', () => {
         </OptGroup>
       </Select>
     );
-    expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: '一' }]);
+    expect(wrapper.state().value).toEqual(['1']);
+    // TODO check title
+    // expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: '一' }]);
   });
 
   it('not add open className when result is empty and no notFoundContent given', () => {
@@ -594,11 +598,9 @@ describe('Select', () => {
     });
 
     it('warns on invalid value when labelInValue', () => {
-      expect(() => {
-        mount(
-          <Select labelInValue value="foo" />
-        );
-      }).toThrow();
+      mount(
+        <Select labelInValue value="foo" />
+      );
       expect(spy.mock.calls[0][0]).toMatch(
         'Warning: Failed prop type: Invalid prop `value` supplied to `Select`, ' +
         'when you set `labelInValue` to `true`,' +
@@ -715,24 +717,15 @@ describe('Select', () => {
 
     input.simulate('keyDown', { keyCode: KeyCode.DOWN });
 
-    expect(wrapper.state().value).toEqual([
-      {
-        key: '2',
-        label: 'Two',
-        backfill: true,
-      },
-    ]);
+    expect(wrapper.state().value).toEqual(['2']);
+    expect(wrapper.state().backfillValue).toEqual('2');
     expect(handleChange).not.toBeCalled();
     expect(handleSelect).not.toBeCalled();
 
     input.simulate('keyDown', { keyCode: KeyCode.ENTER });
 
-    expect(wrapper.state().value).toEqual([
-      {
-        key: '2',
-        label: 'Two',
-      },
-    ]);
+    expect(wrapper.state().value).toEqual(['2']);
+    // TODO add label check
     expect(handleChange).toBeCalledWith('2', expect.anything());
     expect(handleSelect).toBeCalledWith('2', expect.anything());
   });

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -54,15 +54,15 @@ describe('Select', () => {
 
   it('convert value to array', () => {
     const wrapper = mount(
-      <Select value="1">
+      <Select value="1" optionLabelProp="children">
         <OptGroup>
-          <Option value="1" title="一">1</Option>
+          <Option value="1" title="一">1-label</Option>
         </OptGroup>
       </Select>
     );
     expect(wrapper.state().value).toEqual(['1']);
-    // TODO checkout title
-    // expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: '一' }]);
+    expect(wrapper.find('.rc-select-selection-selected-value').text()).toEqual('1-label');
+    expect(wrapper.find('.rc-select-selection-selected-value').prop('title')).toEqual('一');
   });
 
   it('convert defaultValue to array', () => {
@@ -74,8 +74,8 @@ describe('Select', () => {
       </Select>
     );
     expect(wrapper.state().value).toEqual(['1']);
-    // TODO check title
-    // expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: '一' }]);
+    expect(wrapper.find('.rc-select-selection-selected-value').text()).toEqual('1');
+    expect(wrapper.find('.rc-select-selection-selected-value').prop('title')).toEqual('一');
   });
 
   it('not add open className when result is empty and no notFoundContent given', () => {
@@ -725,9 +725,9 @@ describe('Select', () => {
     input.simulate('keyDown', { keyCode: KeyCode.ENTER });
 
     expect(wrapper.state().value).toEqual(['2']);
-    // TODO add label check
     expect(handleChange).toBeCalledWith('2', expect.anything());
     expect(handleSelect).toBeCalledWith('2', expect.anything());
+    expect(wrapper.find('.rc-select-selection-selected-value').text()).toEqual('Two');
   });
 
   describe('number value', () => {

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -294,7 +294,7 @@ describe('Select', () => {
       >
         <OptGroup label="grouplabel">
           <Option value="1" testprop="test">One</Option>
-          </OptGroup>
+        </OptGroup>
         <Option value="2">Two</Option>
       </Select>
     );

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -284,6 +284,29 @@ describe('Select', () => {
     );
   });
 
+  it('give right option when use OptGroup', () => {
+    const handleChange = jest.fn();
+    const wrapper = mount(
+      <Select
+        onChange={handleChange}
+        labelInValue
+        optionLabelProp="children"
+      >
+        <OptGroup label="grouplabel">
+          <Option value="1" testprop="test">One</Option>
+          </OptGroup>
+        <Option value="2">Two</Option>
+      </Select>
+    );
+
+    wrapper.find('.rc-select').simulate('click');
+    wrapper.find('MenuItem').first().simulate('click');
+    expect(handleChange).toBeCalledWith(
+      { key: '1', label: 'One' },
+      <Option value="1" testprop="test">One</Option>
+    );
+  });
+
   it('use label in props.value', () => {
     const wrapper = mount(
       <Select labelInValue value={{ key: 1, label: 'One' }}>

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -284,6 +284,15 @@ describe('Select', () => {
     );
   });
 
+  it('use label in props.value', () => {
+    const wrapper = mount(
+      <Select labelInValue value={{ key: 1, label: 'One' }}>
+        <Option value="2">Two</Option>
+      </Select>
+    );
+    expect(wrapper.find('.rc-select-selection-selected-value').text()).toEqual('One');
+  });
+
   it('fires search event when user input', () => {
     const handleSearch = jest.fn();
     const wrapper = mount(

--- a/tests/Select.tags.spec.js
+++ b/tests/Select.tags.spec.js
@@ -31,7 +31,8 @@ describe('Select.tags', () => {
       .simulate('change', { target: { value: 'foo' } })
       .simulate('keyDown', { keyCode: KeyCode.ENTER });
 
-    expect(wrapper.state().value).toEqual([{ key: 'foo', label: 'foo', title: undefined }]);
+    expect(wrapper.state().value).toEqual(['foo']);
+    // expect(wrapper.state().value).toEqual([{ key: 'foo', label: 'foo', title: undefined }]);
   });
 
   it('should call onChange on blur', () => {
@@ -45,7 +46,9 @@ describe('Select.tags', () => {
       .simulate('blur');
 
     jest.runAllTimers();
-    expect(wrapper.state().value).toEqual([{ key: 'foo', label: 'foo', title: undefined }]);
+    expect(wrapper.state().value).toEqual(['foo']);
+    // TODO check label
+    // expect(wrapper.state().value).toEqual([{ key: 'foo', label: 'foo', title: undefined }]);
   });
 
   it('tokenize input', () => {
@@ -72,11 +75,12 @@ describe('Select.tags', () => {
     expect(handleChange).toBeCalledWith(['2', '3', '4'], expect.anything());
     expect(handleSelect).toHaveBeenCalledTimes(3);
     expect(handleSelect).toHaveBeenLastCalledWith('4', <Option key="4" value="4">4</Option>);
-    expect(wrapper.state().value).toEqual([
-      { key: '2', label: '2' },
-      { key: '3', label: '3' },
-      { key: '4', label: '4' },
-    ]);
+    expect(wrapper.state().value).toEqual(['2', '3', '4']);
+    // TODO add label check
+    //   { key: '2', label: '2' },
+    //   { key: '3', label: '3' },
+    //   { key: '4', label: '4' },
+    // ]);
     expect(wrapper.state().inputValue).toBe('');
     expect(wrapper.state().open).toBe(false);
     expect(input.instance().focus).toBeCalled();
@@ -134,7 +138,9 @@ describe('Select.tags', () => {
       .simulate('change', { target: { value: 'a' } })
       .simulate('keyDown', { keyCode: KeyCode.ENTER });
 
-    expect(wrapper.state().value).toEqual([{ key: 'a', label: 'a', title: undefined }]);
+    expect(wrapper.state().value).toEqual(['a']);
+    // TODO test label
+    // expect(wrapper.state().value).toEqual([{ key: 'a', label: 'a', title: undefined }]);
   });
 
   describe('OptGroup', () => {

--- a/tests/Select.tags.spec.js
+++ b/tests/Select.tags.spec.js
@@ -32,7 +32,9 @@ describe('Select.tags', () => {
       .simulate('keyDown', { keyCode: KeyCode.ENTER });
 
     expect(wrapper.state().value).toEqual(['foo']);
-    // expect(wrapper.state().value).toEqual([{ key: 'foo', label: 'foo', title: undefined }]);
+    expect(
+      wrapper.update().find('.rc-select-selection__choice__content').text()
+    ).toBe('foo');
   });
 
   it('should call onChange on blur', () => {
@@ -47,8 +49,9 @@ describe('Select.tags', () => {
 
     jest.runAllTimers();
     expect(wrapper.state().value).toEqual(['foo']);
-    // TODO check label
-    // expect(wrapper.state().value).toEqual([{ key: 'foo', label: 'foo', title: undefined }]);
+    expect(
+      wrapper.update().find('.rc-select-selection__choice__content').text()
+    ).toBe('foo');
   });
 
   it('tokenize input', () => {
@@ -76,11 +79,15 @@ describe('Select.tags', () => {
     expect(handleSelect).toHaveBeenCalledTimes(3);
     expect(handleSelect).toHaveBeenLastCalledWith('4', <Option key="4" value="4">4</Option>);
     expect(wrapper.state().value).toEqual(['2', '3', '4']);
-    // TODO add label check
-    //   { key: '2', label: '2' },
-    //   { key: '3', label: '3' },
-    //   { key: '4', label: '4' },
-    // ]);
+    expect(
+      wrapper.find('.rc-select-selection__choice__content').at(0).text()
+    ).toBe('2');
+    expect(
+      wrapper.find('.rc-select-selection__choice__content').at(1).text()
+    ).toBe('3');
+    expect(
+      wrapper.find('.rc-select-selection__choice__content').at(2).text()
+    ).toBe('4');
     expect(wrapper.state().inputValue).toBe('');
     expect(wrapper.state().open).toBe(false);
     expect(input.instance().focus).toBeCalled();
@@ -139,8 +146,9 @@ describe('Select.tags', () => {
       .simulate('keyDown', { keyCode: KeyCode.ENTER });
 
     expect(wrapper.state().value).toEqual(['a']);
-    // TODO test label
-    // expect(wrapper.state().value).toEqual([{ key: 'a', label: 'a', title: undefined }]);
+    expect(
+      wrapper.find('.rc-select-selection__choice__content').text()
+    ).toBe('a');
   });
 
   describe('OptGroup', () => {

--- a/tests/shared/dynamicChildrenTest.js
+++ b/tests/shared/dynamicChildrenTest.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+/* eslint-disable no-undef, react/no-multi-comp */
 import React from 'react';
 import Select from '../../src/Select';
 import Option from '../../src/Option';
@@ -18,8 +18,8 @@ export default function dynamicChildrenTest(mode, props) {
       state = {
         value: ['1'],
         options: [
-          <Option key="1" testprop="test">1</Option>,
-          <Option key="2">2</Option>,
+          <Option key="1" testprop="test">1-label</Option>,
+          <Option key="2">2-label</Option>,
         ],
       }
 
@@ -32,8 +32,8 @@ export default function dynamicChildrenTest(mode, props) {
       updateChildren = () => {
         this.setState({
           options: [
-            <Option key="2">2</Option>,
-            <Option key="3">3</Option>,
+            <Option key="2">2-label</Option>,
+            <Option key="3">3-label</Option>,
           ],
         });
       }
@@ -56,12 +56,106 @@ export default function dynamicChildrenTest(mode, props) {
 
     const wrapper = mount(<App />);
     jest.runAllTimers();
+    wrapper.update();
     wrapper.find('.rc-select').simulate('click');
     wrapper.find('MenuItem').at(1).simulate('click');
     expect(onChange).toBeCalledWith(['1', '3'], [
-      <Option key="1" testprop="test">1</Option>,
-      <Option key="3">3</Option>,
+      <Option key="1" testprop="test">1-label</Option>,
+      <Option key="3">3-label</Option>,
     ]);
-    expect(onSelect).toBeCalledWith('3', <Option key="3">3</Option>);
+    expect(onSelect).toBeCalledWith('3', <Option key="3">3-label</Option>);
+  });
+
+  it('value label update with dynamic children', () => {
+    class App extends React.Component {
+      state = {
+        value: 1,
+        options: [
+          <Option key="0" value={0} testprop="test">0-label</Option>,
+          <Option key="1" value={1}>1-label</Option>,
+        ],
+      }
+
+      componentDidMount() {
+        setTimeout(() => {
+          this.updateChildren();
+        }, 10);
+      }
+
+      updateChildren = () => {
+        this.setState({
+          value: 0,
+          options: [
+            <Option key="0" value={0}>0-label-new</Option>,
+            <Option key="1" value={1}>1-label-new</Option>,
+          ],
+        });
+      }
+
+      render() {
+        return (
+          <Select
+            optionLabelProp="children"
+            value={this.state.value}
+            ref={node => this.select = node}
+            {...{ [mode]: true }}
+            {...props}
+          >
+            {this.state.options}
+          </Select>
+        );
+      }
+    }
+
+    const wrapper = mount(<App />);
+    jest.runAllTimers();
+    expect(wrapper.update().find('.rc-select-selection__choice__content').text())
+      .toEqual('0-label-new');
+  });
+
+  it('defaultValue label update with dynamic children', () => {
+    class App extends React.Component {
+      state = {
+        value: ['1'],
+        options: [
+          <Option key="1" testprop="test">1-label</Option>,
+          <Option key="2">2-label</Option>,
+        ],
+      }
+
+      componentDidMount() {
+        setTimeout(() => {
+          this.updateChildren();
+        }, 10);
+      }
+
+      updateChildren = () => {
+        this.setState({
+          options: [
+            <Option key="1">1-label-new</Option>,
+            <Option key="2">2-label</Option>,
+          ],
+        });
+      }
+
+      render() {
+        return (
+          <Select
+            optionLabelProp="children"
+            defaultValue={this.state.value}
+            ref={node => this.select = node}
+            {...{ [mode]: true }}
+            {...props}
+          >
+            {this.state.options}
+          </Select>
+        );
+      }
+    }
+
+    const wrapper = mount(<App />);
+    jest.runAllTimers();
+    expect(wrapper.update().find('.rc-select-selection__choice__content').text())
+      .toEqual('1-label-new');
   });
 }

--- a/tests/shared/removeSelectedTest.js
+++ b/tests/shared/removeSelectedTest.js
@@ -87,7 +87,9 @@ export default function removeSelectedTest(mode) {
       );
 
       wrapper.find('input').simulate('keyDown', { keyCode: KeyCode.BACKSPACE });
-      expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: undefined }]);
+      expect(wrapper.state().value).toEqual(['1']);
+      // TODO
+      // expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: undefined }]);
     });
 
     it('remove by menu deselect', () => {

--- a/tests/shared/removeSelectedTest.js
+++ b/tests/shared/removeSelectedTest.js
@@ -88,8 +88,9 @@ export default function removeSelectedTest(mode) {
 
       wrapper.find('input').simulate('keyDown', { keyCode: KeyCode.BACKSPACE });
       expect(wrapper.state().value).toEqual(['1']);
-      // TODO
-      // expect(wrapper.state().value).toEqual([{ key: '1', label: '1', title: undefined }]);
+      expect(
+        wrapper.find('.rc-select-selection__choice__content').text()
+      ).toBe('1');
     });
 
     it('remove by menu deselect', () => {


### PR DESCRIPTION
And fix https://github.com/ant-design/ant-design/issues/9445

old `state.value`: `[{ key: xxx, label: xxx, title: xxx }]` => new `state.value` : `[ 'xxx', 'xxx' ]`.

state.value only store key. label, title and Option store in optionsInfo.