### PR TITLE
chore: fix aria-* attributes

### DIFF
--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -142,6 +142,7 @@ export default class DropdownMenu extends React.Component {
           ref={saveRef(this, 'menuRef')}
           style={this.props.dropdownMenuStyle}
           defaultActiveFirst={defaultActiveFirstOption}
+          role="listbox"
           {...activeKeyProps}
           multiple={multiple}
           {...menuProps}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -906,6 +906,7 @@ export default class Select extends React.Component {
         const menuItem = (
           <MenuItem
             style={UNSELECTABLE_STYLE}
+            role={null}
             attribute={UNSELECTABLE_ATTRIBUTE}
             value={key}
             key={key}
@@ -937,6 +938,7 @@ export default class Select extends React.Component {
           options.unshift(
             <MenuItem
               style={UNSELECTABLE_STYLE}
+              role={null}
               attribute={UNSELECTABLE_ATTRIBUTE}
               value={inputValue}
               key={inputValue}
@@ -954,6 +956,7 @@ export default class Select extends React.Component {
           style={UNSELECTABLE_STYLE}
           attribute={UNSELECTABLE_ATTRIBUTE}
           disabled
+          role="option"
           value="NOT_FOUND"
           key="NOT_FOUND"
         >
@@ -1015,6 +1018,7 @@ export default class Select extends React.Component {
             attribute={UNSELECTABLE_ATTRIBUTE}
             value={childValue}
             key={childValue}
+            role="option"
             {...child.props}
           />
         );

--- a/src/util.js
+++ b/src/util.js
@@ -111,7 +111,7 @@ export const UNSELECTABLE_STYLE = {
 };
 
 export const UNSELECTABLE_ATTRIBUTE = {
-  unselectable: 'unselectable',
+  unselectable: 'on',
 };
 
 export function findFirstMenuItem(children) {

--- a/tests/__snapshots__/Select.combobox.spec.js.snap
+++ b/tests/__snapshots__/Select.combobox.spec.js.snap
@@ -39,7 +39,7 @@ exports[`Select.combobox allowClear renders correctly 1`] = `
     <span
       class="rc-select-arrow"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     >
       <b />
     </span>
@@ -65,7 +65,7 @@ exports[`Select.combobox renders correctly 1`] = `
       <div
         class="rc-select-selection__placeholder"
         style="display:block;user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       >
         Search
       </div>
@@ -93,7 +93,7 @@ exports[`Select.combobox renders correctly 1`] = `
     <span
       class="rc-select-arrow"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     >
       <b />
     </span>

--- a/tests/__snapshots__/Select.multiple.spec.js.snap
+++ b/tests/__snapshots__/Select.multiple.spec.js.snap
@@ -141,7 +141,7 @@ exports[`Select.multiple render truncates tags by maxTagCount 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -156,7 +156,7 @@ exports[`Select.multiple render truncates tags by maxTagCount 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -171,7 +171,7 @@ exports[`Select.multiple render truncates tags by maxTagCount 1`] = `
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="+ 1 ..."
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -223,7 +223,7 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -238,7 +238,7 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -253,7 +253,7 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="[object Object]"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -307,7 +307,7 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -322,7 +322,7 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -337,7 +337,7 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="[object Object]"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -391,7 +391,7 @@ exports[`Select.multiple render truncates tags by maxTagCount while maxTagCount 
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="+ 3 ..."
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -443,7 +443,7 @@ exports[`Select.multiple render truncates values by maxTagTextLength 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -458,7 +458,7 @@ exports[`Select.multiple render truncates values by maxTagTextLength 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"

--- a/tests/__snapshots__/Select.spec.js.snap
+++ b/tests/__snapshots__/Select.spec.js.snap
@@ -40,7 +40,7 @@ Array [
       <span
         class="rc-select-arrow"
         style="user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       >
         <b />
       </span>
@@ -64,7 +64,7 @@ Array [
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             1
           </li>
@@ -73,7 +73,7 @@ Array [
             class="rc-select-dropdown-menu-item"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             2
           </li>
@@ -124,7 +124,7 @@ Array [
       <span
         class="rc-select-arrow"
         style="user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       >
         <b />
       </span>
@@ -148,7 +148,7 @@ Array [
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             1
           </li>
@@ -157,7 +157,7 @@ Array [
             class="rc-select-dropdown-menu-item"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             2
           </li>
@@ -195,7 +195,7 @@ exports[`Select no search 1`] = `
     <span
       class="rc-select-arrow"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     >
       <b />
     </span>
@@ -222,7 +222,7 @@ exports[`Select render renders correctly 1`] = `
       <div
         class="antd-selection__placeholder"
         style="display:none;user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       >
         Select a number
       </div>
@@ -256,12 +256,12 @@ exports[`Select render renders correctly 1`] = `
     <span
       class="antd-selection__clear"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     />
     <span
       class="antd-arrow"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     >
       <b />
     </span>
@@ -288,7 +288,7 @@ exports[`Select render renders disabeld select correctly 1`] = `
       <div
         class="antd-selection__placeholder"
         style="display:none;user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       >
         Select a number
       </div>
@@ -323,12 +323,12 @@ exports[`Select render renders disabeld select correctly 1`] = `
     <span
       class="antd-selection__clear"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     />
     <span
       class="antd-arrow"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     >
       <b />
     </span>
@@ -356,7 +356,7 @@ Array [
         <div
           class="antd-selection__placeholder"
           style="display:none;user-select:none;-webkit-user-select:none"
-          unselectable="unselectable"
+          unselectable="on"
         >
           Select a number
         </div>
@@ -390,12 +390,12 @@ Array [
       <span
         class="antd-selection__clear"
         style="user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       />
       <span
         class="antd-arrow"
         style="user-select:none;-webkit-user-select:none"
-        unselectable="unselectable"
+        unselectable="on"
       >
         <b />
       </span>
@@ -431,7 +431,7 @@ Array [
                 class="antd-dropdown-menu-item option-test antd-dropdown-menu-item-active"
                 role="menuitem"
                 style="user-select:none;-webkit-user-select:none"
-                unselectable="unselectable"
+                unselectable="on"
               >
                 <b
                   style="color:red"
@@ -444,7 +444,7 @@ Array [
                 class="antd-dropdown-menu-item"
                 role="menuitem"
                 style="user-select:none;-webkit-user-select:none"
-                unselectable="unselectable"
+                unselectable="on"
               >
                 lucy
               </li>
@@ -467,7 +467,7 @@ Array [
                 class="antd-dropdown-menu-item"
                 role="menuitem"
                 style="user-select:none;-webkit-user-select:none"
-                unselectable="unselectable"
+                unselectable="on"
               >
                 yiminghe
               </li>
@@ -526,7 +526,7 @@ exports[`Select should contian falsy children 1`] = `
     <span
       class="rc-select-arrow"
       style="user-select:none;-webkit-user-select:none"
-      unselectable="unselectable"
+      unselectable="on"
     >
       <b />
     </span>

--- a/tests/__snapshots__/Select.tags.spec.js.snap
+++ b/tests/__snapshots__/Select.tags.spec.js.snap
@@ -21,7 +21,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
           <li
             class="rc-select-selection__choice"
             title="jack"
-            unselectable="unselectable"
+            unselectable="on"
           >
             <div
               class="rc-select-selection__choice__content"
@@ -35,7 +35,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
           <li
             class="rc-select-selection__choice"
             title="foo"
-            unselectable="unselectable"
+            unselectable="on"
           >
             <div
               class="rc-select-selection__choice__content"
@@ -99,7 +99,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
                 class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active rc-select-dropdown-menu-item-selected"
                 role="menuitem"
                 style=""
-                unselectable="unselectable"
+                unselectable="on"
               >
                 Jack
               </li>
@@ -121,7 +121,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
                 aria-selected="false"
                 class="rc-select-dropdown-menu-item"
                 role="menuitem"
-                unselectable="unselectable"
+                unselectable="on"
               >
                 yiminghe
               </li>
@@ -131,7 +131,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
             aria-selected="true"
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-selected"
             role="menuitem"
-            unselectable="unselectable"
+            unselectable="on"
           >
             foo
           </li>
@@ -202,7 +202,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 1`] = `
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active"
             role="menuitem"
             style=""
-            unselectable="unselectable"
+            unselectable="on"
           >
             foo
           </li>
@@ -234,7 +234,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 2`] = `
           <li
             class="rc-select-selection__choice"
             title="foo"
-            unselectable="unselectable"
+            unselectable="on"
           >
             <div
               class="rc-select-selection__choice__content"
@@ -299,7 +299,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 2`] = `
                 class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active"
                 role="menuitem"
                 style=""
-                unselectable="unselectable"
+                unselectable="on"
               >
                 Jack
               </li>
@@ -321,7 +321,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 2`] = `
                 aria-selected="false"
                 class="rc-select-dropdown-menu-item"
                 role="menuitem"
-                unselectable="unselectable"
+                unselectable="on"
               >
                 yiminghe
               </li>
@@ -332,7 +332,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 2`] = `
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-selected"
             role="menuitem"
             style=""
-            unselectable="unselectable"
+            unselectable="on"
           >
             foo
           </li>
@@ -484,7 +484,7 @@ exports[`Select.tags render truncates tags by maxTagCount 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -499,7 +499,7 @@ exports[`Select.tags render truncates tags by maxTagCount 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -514,7 +514,7 @@ exports[`Select.tags render truncates tags by maxTagCount 1`] = `
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="+ 1 ..."
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -566,7 +566,7 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -581,7 +581,7 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -596,7 +596,7 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="[object Object]"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -650,7 +650,7 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -665,7 +665,7 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -680,7 +680,7 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="[object Object]"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -734,7 +734,7 @@ exports[`Select.tags render truncates tags by maxTagCount while maxTagCount is 0
           class="rc-select-selection__choice rc-select-selection__choice__disabled"
           style="user-select:none;-webkit-user-select:none"
           title="+ 3 ..."
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -786,7 +786,7 @@ exports[`Select.tags render truncates values by maxTagTextLength 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="one"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -801,7 +801,7 @@ exports[`Select.tags render truncates values by maxTagTextLength 1`] = `
           class="rc-select-selection__choice"
           style="user-select:none;-webkit-user-select:none"
           title="two"
-          unselectable="unselectable"
+          unselectable="on"
         >
           <div
             class="rc-select-selection__choice__content"
@@ -857,7 +857,7 @@ Array [
             class="rc-select-selection__choice"
             style="user-select:none;-webkit-user-select:none"
             title="22"
-            unselectable="unselectable"
+            unselectable="on"
           >
             <div
               class="rc-select-selection__choice__content"
@@ -908,7 +908,7 @@ Array [
             class="rc-select-dropdown-menu-item"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             1
           </li>
@@ -917,7 +917,7 @@ Array [
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active rc-select-dropdown-menu-item-selected"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             22
           </li>
@@ -949,7 +949,7 @@ Array [
             class="rc-select-selection__choice"
             style="user-select:none;-webkit-user-select:none"
             title="3"
-            unselectable="unselectable"
+            unselectable="on"
           >
             <div
               class="rc-select-selection__choice__content"
@@ -1000,7 +1000,7 @@ Array [
             class="rc-select-dropdown-menu-item"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             1
           </li>
@@ -1009,7 +1009,7 @@ Array [
             class="rc-select-dropdown-menu-item"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             2
           </li>
@@ -1018,7 +1018,7 @@ Array [
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active rc-select-dropdown-menu-item-selected"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             3
           </li>
@@ -1086,7 +1086,7 @@ Array [
             class="rc-select-dropdown-menu-item rc-select-dropdown-menu-item-active"
             role="menuitem"
             style="user-select:none;-webkit-user-select:none"
-            unselectable="unselectable"
+            unselectable="on"
           >
             Red
           </li>


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/10095

before:
<img width="718" alt="antd-select-before" src="https://user-images.githubusercontent.com/1731837/39364957-5b3b9dd0-4a62-11e8-87cf-10d5edbab2c3.png">
after:
(weird that there are no incidents of aria-* error but still print an empty list) 
<img width="726" alt="antd-select-after" src="https://user-images.githubusercontent.com/1731837/39364959-5c795eee-4a62-11e8-93b3-8f5f2566a260.png">

also: value of unselectable should be `on` or `off`
https://stackoverflow.com/questions/69430/is-there-a-way-to-make-text-unselectable-on-an-html-page (could not find an official doc...)