### PR TITLE
fix 'react-lifecycles-compat' affect in react 16.2.0

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -378,12 +378,16 @@ class Select extends React.Component {
     const optionsInfo = prevState.skipBuildOptionsInfo
                         ? prevState.optionsInfo
                         : Select.getOptionsInfoFromProps(nextProps, prevState);
-    const open = 'open' in nextProps ? nextProps.open : prevState.open;
+
     const newState = {
       optionsInfo,
-      open,
       skipBuildOptionsInfo: false,
     };
+
+    if ('open' in nextProps) {
+      newState.open = nextProps.open;
+    }
+
     if ('value' in nextProps) {
       const value = Select.getValueFromProps(nextProps);
       newState.value = value;


### PR DESCRIPTION
Test case already in `Select.spec.js > 'close after select'`. No need additional test case.

ref: https://github.com/ant-design/ant-design/issues/10400