### PR TITLE
[enhancement] - Scrolling performance issues

### DIFF
--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -161,7 +161,10 @@ export default class DropdownMenu extends React.Component {
     const renderMenu = this.renderMenu();
     return renderMenu ? (
       <div
-        style={{ overflow: 'auto' }}
+        style={{
+          overflow: 'auto',
+          transform: 'translateZ(0)',
+        }}
         onFocus={this.props.onPopupFocus}
         onMouseDown={preventDefaultEvent}
         onScroll={this.props.onPopupScroll}

--- a/tests/__snapshots__/DropdownMenu.spec.js.snap
+++ b/tests/__snapshots__/DropdownMenu.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DropdownMenu renders correctly 1`] = `
 <div
-  style="overflow:auto"
+  style="overflow:auto;transform:translateZ(0)"
 >
   <ul
     class="undefined-menu  undefined-menu-root undefined-menu-vertical"

--- a/tests/__snapshots__/Select.spec.js.snap
+++ b/tests/__snapshots__/Select.spec.js.snap
@@ -51,7 +51,7 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--single rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        style="overflow:auto"
+        style="overflow:auto;transform:translateZ(0)"
       >
         <ul
           class="rc-select-dropdown-menu  rc-select-dropdown-menu-root rc-select-dropdown-menu-vertical"
@@ -134,7 +134,7 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--single rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        style="overflow:auto"
+        style="overflow:auto;transform:translateZ(0)"
       >
         <ul
           class="rc-select-dropdown-menu  rc-select-dropdown-menu-root rc-select-dropdown-menu-vertical"
@@ -404,7 +404,7 @@ Array [
       class="antd-dropdown antd-dropdown--single antd-dropdown-placement-bottomLeft "
     >
       <div
-        style="overflow:auto"
+        style="overflow:auto;transform:translateZ(0)"
       >
         <ul
           class="antd-dropdown-menu  antd-dropdown-menu-root antd-dropdown-menu-vertical"

--- a/tests/__snapshots__/Select.tags.spec.js.snap
+++ b/tests/__snapshots__/Select.tags.spec.js.snap
@@ -892,7 +892,7 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--multiple rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        style="overflow:auto"
+        style="overflow:auto;transform:translateZ(0)"
       >
         <ul
           class="rc-select-dropdown-menu  rc-select-dropdown-menu-root rc-select-dropdown-menu-vertical"
@@ -983,7 +983,7 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--multiple rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        style="overflow:auto"
+        style="overflow:auto;transform:translateZ(0)"
       >
         <ul
           class="rc-select-dropdown-menu  rc-select-dropdown-menu-root rc-select-dropdown-menu-vertical"
@@ -1068,7 +1068,7 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--multiple rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        style="overflow:auto"
+        style="overflow:auto;transform:translateZ(0)"
       >
         <ul
           class="rc-select-dropdown-menu  rc-select-dropdown-menu-root rc-select-dropdown-menu-vertical"


### PR DESCRIPTION
This commit will resolve a known scrolling performance issue related to scrollable areas.
The thing is that scrolling force repaints (draw the UI pixels) whenever the user is scrolling,
and that causes a lot of repaints that could be avoided using GPU accelerated repaints.

For legacy fix I'm using transform: translateZ(0) which will give the GPU to handle those repaints which make
the scrolling performance more better

Affected pages among the examples with this issue:
- http://react-component.github.io/select/examples/tags.html
- http://react-component.github.io/select/examples/single.html
- http://react-component.github.io/select/examples/multiple.html

Inspect the Chrome "rendering" tab in Devtools to validate the issue.
I'll be attaching a screenshots for the reproduction