### PR TITLE
fix: include disabled item for searching tag item in options

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -1048,7 +1048,8 @@ class Select extends React.Component {
         sel.push(menuItem);
         menuItems.push(menuItem);
       }
-      if (tags && !child.props.disabled) {
+
+      if (tags) {
         childrenKeys.push(childValue);
       }
     });

--- a/tests/Select.spec.js
+++ b/tests/Select.spec.js
@@ -703,6 +703,16 @@ describe('Select', () => {
     expect(wrapper.find('li').text()).toEqual('1');
   });
 
+  it('should include disabled item in options', () => {
+    const wrapper = mount(
+      <Select tags open value={['name1']}>
+        <Option key="name1" disabled>name1</Option>
+        <Option key="name2">name2</Option>
+      </Select>
+    );
+    expect(wrapper.find('li.rc-select-dropdown-menu-item')).toHaveLength(2);
+  });
+
   it('renders not found when search result is empty', () => {
     const wrapper = mount(
       <Select open>


### PR DESCRIPTION
Closing https://github.com/react-component/select/issues/308 and https://github.com/ant-design/ant-design/issues/10833