### PR TITLE
feature: Added onMenuOpen and onMenuClose

### DIFF
--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -40,8 +40,8 @@ export default class DropdownMenu extends React.Component {
     if (!nextProps.visible) {
       this.lastVisible = false;
     }
-    
-    if(this.props.visible !== nextProps.visible) {
+
+    if (this.props.visible !== nextProps.visible) {
       this.handleMenuChange(nextProps.visible);
     }
     // freeze when hide
@@ -82,12 +82,12 @@ export default class DropdownMenu extends React.Component {
   };
 
   handleMenuChange(visible) {
-    if(visible) {
-      if(this.props.onMenuOpen) {
+    if (visible) {
+      if (this.props.onMenuOpen) {
         this.props.onMenuOpen();
       }
     } else {
-      if(this.props.onMenuClose) {
+      if (this.props.onMenuClose) {
         this.props.onMenuClose();
       }
     }

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -31,9 +31,7 @@ export default class DropdownMenu extends React.Component {
   }
 
   componentDidMount() {
-    if(this.props.onMenuOpen) {
-      this.props.onMenuOpen();
-    }
+    this.handleMenuChange(this.props.visible);
     this.scrollActiveItemToView();
     this.lastVisible = this.props.visible;
   }
@@ -43,14 +41,8 @@ export default class DropdownMenu extends React.Component {
       this.lastVisible = false;
     }
     
-    if(nextProps.visible) {
-      if(this.props.onMenuOpen) {
-        this.props.onMenuOpen();
-      }
-    } else {
-      if(this.props.onMenuClose) {
-        this.props.onMenuClose();
-      }
+    if(this.props.visible !== nextProps.visible) {
+      this.handleMenuChange(nextProps.visible);
     }
     // freeze when hide
     return nextProps.visible;
@@ -88,6 +80,18 @@ export default class DropdownMenu extends React.Component {
       );
     }
   };
+
+  handleMenuChange(visible) {
+    if(visible) {
+      if(this.props.onMenuOpen) {
+        this.props.onMenuOpen();
+      }
+    } else {
+      if(this.props.onMenuClose) {
+        this.props.onMenuClose();
+      }
+    }
+  }
 
   renderMenu() {
     const props = this.props;

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -16,6 +16,8 @@ export default class DropdownMenu extends React.Component {
     onPopupScroll: PropTypes.func,
     onMenuDeSelect: PropTypes.func,
     onMenuSelect: PropTypes.func,
+    onMenuOpen: PropTypes.func,
+    onMenuClose: PropTypes.func,
     prefixCls: PropTypes.string,
     menuItems: PropTypes.any,
     inputValue: PropTypes.string,
@@ -29,6 +31,9 @@ export default class DropdownMenu extends React.Component {
   }
 
   componentDidMount() {
+    if(this.props.onMenuOpen) {
+      this.props.onMenuOpen();
+    }
     this.scrollActiveItemToView();
     this.lastVisible = this.props.visible;
   }
@@ -36,6 +41,16 @@ export default class DropdownMenu extends React.Component {
   shouldComponentUpdate(nextProps) {
     if (!nextProps.visible) {
       this.lastVisible = false;
+    }
+    
+    if(nextProps.visible) {
+      if(this.props.onMenuOpen) {
+        this.props.onMenuOpen();
+      }
+    } else {
+      if(this.props.onMenuClose) {
+        this.props.onMenuClose();
+      }
     }
     // freeze when hide
     return nextProps.visible;

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -64,6 +64,8 @@ export const SelectPropTypes = {
   onSelect: PropTypes.func,
   onSearch: PropTypes.func,
   onPopupScroll: PropTypes.func,
+  onMenuOpen: PropTypes.func,
+  onMenuClose: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   onInputKeyDown: PropTypes.func,

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -1316,6 +1316,8 @@ class Select extends React.Component {
         getPopupContainer={props.getPopupContainer}
         onMenuSelect={this.onMenuSelect}
         onMenuDeselect={this.onMenuDeselect}
+        onMenuOpen={props.onMenuOpen}
+        onMenuClose={props.onMenuClose}
         onPopupScroll={props.onPopupScroll}
         showAction={props.showAction}
         ref={this.saveSelectTriggerRef}

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -31,6 +31,8 @@ export default class SelectTrigger extends React.Component {
   static propTypes = {
     onPopupFocus: PropTypes.func,
     onPopupScroll: PropTypes.func,
+    onMenuOpen: PropTypes.func,
+    onMenuClose: PropTypes.func,
     dropdownMatchSelectWidth: PropTypes.bool,
     dropdownAlign: PropTypes.object,
     visible: PropTypes.bool,
@@ -90,6 +92,8 @@ export default class SelectTrigger extends React.Component {
         prefixCls={this.getDropdownPrefixCls()}
         onMenuSelect={props.onMenuSelect}
         onMenuDeselect={props.onMenuDeselect}
+        onMenuOpen={props.onMenuOpen}
+        onMenuClose={props.onMenuClose}
         onPopupScroll={props.onPopupScroll}
         value={props.value}
         backfillValue={props.backfillValue}

--- a/tests/DropdownMenu.spec.js
+++ b/tests/DropdownMenu.spec.js
@@ -135,7 +135,8 @@ describe('DropdownMenu', () => {
   });
 
   it('should trigger onMenuOpen and onMenuClose', () => {
-    let openCalled = false, closeCalled = false;
+    let openCalled = false;
+    let closeCalled = false;
     const wrapper = mount(
       <DropdownMenu
         onMenuOpen={() => openCalled = true}
@@ -145,7 +146,7 @@ describe('DropdownMenu', () => {
 
     wrapper.setProps({ visible: true });
     expect(openCalled).toBe(true);
-    
+
     wrapper.setProps({ visible: false });
     expect(closeCalled).toBe(true);
   });

--- a/tests/DropdownMenu.spec.js
+++ b/tests/DropdownMenu.spec.js
@@ -133,4 +133,20 @@ describe('DropdownMenu', () => {
     expect(wrapper.instance().shouldComponentUpdate({ visible: true })).toBe(true);
     expect(wrapper.instance().shouldComponentUpdate({ visible: false })).toBe(false);
   });
+
+  it('should trigger onMenuOpen and onMenuClose', () => {
+    let openCalled = false, closeCalled = false;
+    const wrapper = mount(
+      <DropdownMenu
+        onMenuOpen={() => openCalled = true}
+        onMenuClose={() => closeCalled = true}
+      />
+    );
+
+    wrapper.setProps({ visible: true });
+    expect(openCalled).toBe(true);
+    
+    wrapper.setProps({ visible: false });
+    expect(closeCalled).toBe(true);
+  });
 });


### PR DESCRIPTION
While fixing an issue of mine, I needed to know when the dropdown menu was opened and when it was closed. I added onMenuOpen and onMenuClose props, they're triggered whenever the menu become visible and when it's not.