### PR TITLE
暴露hideAction给外边

### DIFF
--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -82,6 +82,7 @@ export const SelectPropTypes = {
   tokenSeparators: PropTypes.arrayOf(PropTypes.string),
   getInputElement: PropTypes.func,
   showAction: PropTypes.arrayOf(PropTypes.string),
+  hideAction: PropTypes.arrayOf(PropTypes.string),
   clearIcon: PropTypes.node,
   inputIcon: PropTypes.node,
   removeIcon: PropTypes.node,

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -76,6 +76,7 @@ class Select extends React.Component {
     notFoundContent: 'Not Found',
     backfill: false,
     showAction: ['click'],
+    hideAction: ['click'],
     tokenSeparators: [],
     autoClearSearchValue: true,
   };
@@ -1320,6 +1321,7 @@ class Select extends React.Component {
         onMenuDeselect={this.onMenuDeselect}
         onPopupScroll={props.onPopupScroll}
         showAction={props.showAction}
+        hideAction={props.hideAction}
         ref={this.saveSelectTriggerRef}
       >
         <div

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -45,6 +45,7 @@ export default class SelectTrigger extends React.Component {
     popupClassName: PropTypes.string,
     children: PropTypes.any,
     showAction: PropTypes.arrayOf(PropTypes.string),
+    hideAction: PropTypes.arrayOf(PropTypes.string),
   };
 
   constructor(props) {
@@ -138,14 +139,6 @@ export default class SelectTrigger extends React.Component {
       inputValue,
       visible,
     });
-    let hideAction;
-    if (disabled) {
-      hideAction = [];
-    } else if (isSingleMode(props) && !showSearch) {
-      hideAction = ['click'];
-    } else {
-      hideAction = ['blur'];
-    }
     const popupStyle = { ...dropdownStyle };
     const widthProp = dropdownMatchSelectWidth ? 'width' : 'minWidth';
     if (this.state.dropdownWidth) {
@@ -156,7 +149,7 @@ export default class SelectTrigger extends React.Component {
       <Trigger
         {...props}
         showAction={disabled ? [] : this.props.showAction}
-        hideAction={hideAction}
+        hideAction={disabled ? [] : this.props.hideAction}
         ref={this.saveTriggerRef}
         popupPlacement="bottomLeft"
         builtinPlacements={BUILT_IN_PLACEMENTS}


### PR DESCRIPTION
比如如果需要由hover触发select展开与关闭时，外部可以通过showAction和hideAction控制