### PR TITLE
Support Menu Item Icon suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ React.render(c, container);
 | inputIcon | specify the select arrow icon | ReactNode | - |
 | clearIcon | specify the clear icon | ReactNode | - |
 | removeIcon | specify the remove icon | ReactNode | - |
-| menuItemIcon | specify the remove icon | ReactNode \| (props: MenuItemProps) => ReactNode | - |
+| menuItemSelectedIcon | specify the remove icon | ReactNode \| (props: MenuItemProps) => ReactNode | - |
 
 
 ### Methods

--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ React.render(c, container);
 |showAction| actions trigger the dropdown to show | String[]? | - |
 |autoFocus| focus select after mount | Bool | - |
 | autoClearSearchValue | auto clear search input value when multiple select is selected/deselected | boolean | true |
-| inputIcon | specific the select arrow icon | ReactNode | - |
-| clearIcon | specific the clear icon | ReactNode | - |
-| removeIcon | specific the remove icon | ReactNode | - |
+| inputIcon | specify the select arrow icon | ReactNode | - |
+| clearIcon | specify the clear icon | ReactNode | - |
+| removeIcon | specify the remove icon | ReactNode | - |
+| menuItemIcon | specify the remove icon | ReactNode \| (props: MenuItemProps) => ReactNode | - |
 
 
 ### Methods

--- a/examples/custom-icon.js
+++ b/examples/custom-icon.js
@@ -23,6 +23,19 @@ const clearPath = 'M793 242H366v-74c0-6.7-7.7-10.4-12.9' +
   ' 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h618c35.3 0 64-' +
   '28.7 64-64V306c0-35.3-28.7-64-64-64z';
 
+const menuItemIcon = props => {
+  const { ...p } = props;
+  return (
+    <span style={{ position: 'absolute', right: 0 }}>
+      {p.isSelected ? '🌹' : '☑️'}
+    </span>
+  );
+};
+
+const singleItemIcon = (
+  <span style={{ position: 'absolute', right: '0px' }}>🌹</span>
+);
+
 const getSvg = (path) => {
   return (
     <i>
@@ -97,6 +110,7 @@ class Demo extends React.Component {
           removeIcon={getSvg(clearPath, {
             className: `custom-remove-icon`,
           }, true)}
+          menuItemIcon={singleItemIcon}
         >
           <Option value="jack">
             <b style={{ color: 'red' }}>jack</b>
@@ -182,6 +196,7 @@ class Test extends React.Component {
             inputIcon={getSvg(arrowPath)}
             clearIcon={getSvg(clearPath)}
             removeIcon={getSvg(clearPath)}
+            menuItemIcon={menuItemIcon}
           >
             {children}
           </Select>

--- a/examples/custom-icon.js
+++ b/examples/custom-icon.js
@@ -23,7 +23,7 @@ const clearPath = 'M793 242H366v-74c0-6.7-7.7-10.4-12.9' +
   ' 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h618c35.3 0 64-' +
   '28.7 64-64V306c0-35.3-28.7-64-64-64z';
 
-const menuItemIcon = props => {
+const menuItemSelectedIcon = props => {
   const { ...p } = props;
   return (
     <span style={{ position: 'absolute', right: 0 }}>
@@ -110,7 +110,7 @@ class Demo extends React.Component {
           removeIcon={getSvg(clearPath, {
             className: `custom-remove-icon`,
           }, true)}
-          menuItemIcon={singleItemIcon}
+          menuItemSelectedIcon={singleItemIcon}
         >
           <Option value="jack">
             <b style={{ color: 'red' }}>jack</b>
@@ -196,7 +196,7 @@ class Test extends React.Component {
             inputIcon={getSvg(arrowPath)}
             clearIcon={getSvg(clearPath)}
             removeIcon={getSvg(clearPath)}
-            menuItemIcon={menuItemIcon}
+            menuItemSelectedIcon={menuItemSelectedIcon}
           >
             {children}
           </Select>

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -23,7 +23,7 @@ export default class DropdownMenu extends React.Component {
     inputValue: PropTypes.string,
     visible: PropTypes.bool,
     firstActiveValue: PropTypes.string,
-    menuItemIcon: PropTypes.oneOfType([
+    menuItemSelectedIcon: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.node,
     ]),
@@ -95,7 +95,7 @@ export default class DropdownMenu extends React.Component {
     const props = this.props;
     const {
       menuItems,
-      menuItemIcon,
+      menuItemSelectedIcon,
       defaultActiveFirstOption,
       value,
       prefixCls,
@@ -167,7 +167,7 @@ export default class DropdownMenu extends React.Component {
           style={this.props.dropdownMenuStyle}
           defaultActiveFirst={defaultActiveFirstOption}
           role="listbox"
-          itemIcon={menuItemIcon}
+          itemIcon={menuItemSelectedIcon}
           {...activeKeyProps}
           multiple={multiple}
           {...menuProps}

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -23,6 +23,10 @@ export default class DropdownMenu extends React.Component {
     inputValue: PropTypes.string,
     visible: PropTypes.bool,
     firstActiveValue: PropTypes.string,
+    menuItemIcon: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.node,
+    ]),
   };
 
   constructor(props) {
@@ -91,6 +95,7 @@ export default class DropdownMenu extends React.Component {
     const props = this.props;
     const {
       menuItems,
+      menuItemIcon,
       defaultActiveFirstOption,
       value,
       prefixCls,
@@ -162,6 +167,7 @@ export default class DropdownMenu extends React.Component {
           style={this.props.dropdownMenuStyle}
           defaultActiveFirst={defaultActiveFirstOption}
           role="listbox"
+          itemIcon={menuItemIcon}
           {...activeKeyProps}
           multiple={multiple}
           {...menuProps}

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -85,4 +85,8 @@ export const SelectPropTypes = {
   clearIcon: PropTypes.node,
   inputIcon: PropTypes.node,
   removeIcon: PropTypes.node,
+  menuItemIcon: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.node,
+  ]),
 };

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -85,7 +85,7 @@ export const SelectPropTypes = {
   clearIcon: PropTypes.node,
   inputIcon: PropTypes.node,
   removeIcon: PropTypes.node,
-  menuItemIcon: PropTypes.oneOfType([
+  menuItemSelectedIcon: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.node,
   ]),

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -1334,6 +1334,7 @@ class Select extends React.Component {
         onPopupScroll={props.onPopupScroll}
         showAction={props.showAction}
         ref={this.saveSelectTriggerRef}
+        menuItemIcon={props.menuItemIcon}
       >
         <div
           id={props.id}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -1334,7 +1334,7 @@ class Select extends React.Component {
         onPopupScroll={props.onPopupScroll}
         showAction={props.showAction}
         ref={this.saveSelectTriggerRef}
-        menuItemIcon={props.menuItemIcon}
+        menuItemSelectedIcon={props.menuItemSelectedIcon}
       >
         <div
           id={props.id}

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -45,6 +45,10 @@ export default class SelectTrigger extends React.Component {
     popupClassName: PropTypes.string,
     children: PropTypes.any,
     showAction: PropTypes.arrayOf(PropTypes.string),
+    menuItemIcon: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.node,
+    ]),
   };
 
   constructor(props) {
@@ -99,6 +103,7 @@ export default class SelectTrigger extends React.Component {
         firstActiveValue={props.firstActiveValue}
         defaultActiveFirstOption={props.defaultActiveFirstOption}
         dropdownMenuStyle={props.dropdownMenuStyle}
+        menuItemIcon={props.menuItemIcon}
       />
     );
   };

--- a/src/SelectTrigger.jsx
+++ b/src/SelectTrigger.jsx
@@ -45,7 +45,7 @@ export default class SelectTrigger extends React.Component {
     popupClassName: PropTypes.string,
     children: PropTypes.any,
     showAction: PropTypes.arrayOf(PropTypes.string),
-    menuItemIcon: PropTypes.oneOfType([
+    menuItemSelectedIcon: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.node,
     ]),
@@ -103,7 +103,7 @@ export default class SelectTrigger extends React.Component {
         firstActiveValue={props.firstActiveValue}
         defaultActiveFirstOption={props.defaultActiveFirstOption}
         dropdownMenuStyle={props.dropdownMenuStyle}
-        menuItemIcon={props.menuItemIcon}
+        menuItemSelectedIcon={props.menuItemSelectedIcon}
       />
     );
   };


### PR DESCRIPTION
暴露 `menuItemIcon` 接口供 `antd` 使用。用于解决下面的问题：
![image](https://user-images.githubusercontent.com/15819224/44984716-63e72e00-afb0-11e8-9641-7f9ca66b24d8.png)
期望：
<img width="482" alt="2018-09-03 7 39 09" src="https://user-images.githubusercontent.com/15819224/44984951-1a4b1300-afb1-11e8-8311-ac090317143e.png">
