### PR TITLE
bugfix: focus not work in single mode

### DIFF
--- a/examples/combobox.js
+++ b/examples/combobox.js
@@ -53,6 +53,8 @@ class Demo extends React.Component {
           value={this.state.value}
           combobox
           backfill
+          onFocus={() => console.log('focus')}
+          onBlur={() => console.log('blur')}
         >
           <Option value="jack">
             <b style={{ color: 'red' }}>jack</b>

--- a/examples/suggest.js
+++ b/examples/suggest.js
@@ -64,6 +64,8 @@ class Search extends React.Component {
           onChange={this.fetchData}
           onSelect={this.onSelect}
           filterOption={false}
+          onFocus={() => console.log('focus')}
+          onBlur={() => console.log('blur')}
         >
           {options}
         </Select>

--- a/examples/tags.js
+++ b/examples/tags.js
@@ -62,6 +62,8 @@ class Test extends React.Component {
             onSelect={this.onSelect}
             onDeselect={this.onDeselect}
             tokenSeparators={[' ', ',']}
+            onFocus={() => console.log('focus')}
+            onBlur={() => console.log('blur')}
           >
             {children}
           </Select>

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -323,7 +323,8 @@ class Select extends React.Component {
     }
     this._focused = true;
     this.updateFocusClassName();
-    if (!this._mouseDown) {
+    // only effect multiple or tag mode
+    if (!isMultipleOrTags(this.props) || !this._mouseDown) {
       this.timeoutFocus();
     }
   };


### PR DESCRIPTION
修复 https://github.com/react-component/select/pull/327 导致的single、combobox模式下focus触发异常的问题。

这个问题的原因是
多选的情况下，onFocus是直接在onDropdownVisibleChange事件里调用的。
而在单选情况下，鼠标按下时就会触发focus事件，这个时候onOuterFocus里调用onFocus的代码被上次的提交里加的_mouseDown判断拦截了，因为这个时候已经focus了，所以在onDropdownVisibleChange里不会再调用onFocus了。这次的pr主要就是绕过单选模式下onOuterFocus里的_mouseDown判断，因为本质上是没必要的。

ps: _mouseDown是在上面pr里防止点击select多次触发focus的flag。