### PR TITLE
adding spaces on search in single mode

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -184,7 +184,7 @@ class Select extends React.Component {
     } else if (
       keyCode === KeyCode.ENTER ||
       keyCode === KeyCode.DOWN ||
-      keyCode === KeyCode.SPACE
+      (isMultipleOrTags(this.props) && (keyCode === KeyCode.SPACE))
     ) {
       if (!open) this.setOpenState(true);
       event.preventDefault();


### PR DESCRIPTION
This solves the bug where one can't enter SPACE while searching for options in single mode. Ref #333 