### PR TITLE
skip generating a uuid if props.id is present

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -16,7 +16,7 @@ export interface IMenuEvent {
 }
 
 export interface IDropdownMenuProps {
-  ariaId: string;
+  id: string;
   defaultActiveFirstOption: boolean;
   value: valueType;
   dropdownMenuStyle: React.CSSProperties;
@@ -37,7 +37,7 @@ export interface IDropdownMenuProps {
 export default class DropdownMenu extends React.Component<Partial<IDropdownMenuProps>> {
   public static displayName = 'DropdownMenu';
   public static propTypes = {
-    ariaId: PropTypes.string,
+    id: PropTypes.string,
     defaultActiveFirstOption: PropTypes.bool,
     value: PropTypes.any,
     dropdownMenuStyle: PropTypes.object,
@@ -230,7 +230,7 @@ export default class DropdownMenu extends React.Component<Partial<IDropdownMenuP
           overflow: 'auto',
           transform: 'translateZ(0)',
         }}
-        id={this.props.ariaId}
+        id={this.props.id}
         onFocus={this.props.onPopupFocus}
         onMouseDown={preventDefaultEvent}
         onScroll={this.props.onPopupScroll}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -59,7 +59,7 @@ export interface ISelectState {
   skipBuildOptionsInfo?: boolean;
   optionsInfo?: any;
   backfillValue?: string;
-  ariaId?: string;
+  id?: string;
 }
 
 class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
@@ -117,6 +117,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
         newState.inputValue = Select.getInputValueForCombobox(nextProps, optionsInfo);
       }
     }
+
+    if ('id' in nextProps) {
+      newState.id = nextProps.id;
+    }
+
     return newState;
   };
 
@@ -257,7 +262,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
       backfillValue: '',
       // a flag for aviod redundant getOptionsInfoFromProps call
       skipBuildOptionsInfo: true,
-      ariaId: '',
+      id: props.id,
     };
 
     this.saveInputRef = saveRef(this, 'inputRef');
@@ -272,9 +277,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     if (this.props.autoFocus) {
       this.focus();
     }
-    this.setState({
-      ariaId: generateUUID(),
-    });
+    if (!this.state.id) {
+      this.setState({
+        id: generateUUID(),
+      });
+    }
   }
 
   public componentDidUpdate() {
@@ -1451,10 +1458,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     const state = this.state;
     const { className, disabled, prefixCls } = props;
     const ctrlNode = this.renderTopControlNode();
-    const { open, ariaId } = this.state;
+    const { open, id } = this.state;
     if (open) {
       this._options = this.renderFilterOptions();
     }
+    const popupId = id && `${id}__popup`;
     const realOpen = this.getRealOpenState();
     const options = this._options || [];
     const dataOrAriaAttributeProps = {};
@@ -1526,10 +1534,10 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
         ref={this.saveSelectTriggerRef}
         menuItemSelectedIcon={props.menuItemSelectedIcon}
         dropdownRender={props.dropdownRender}
-        ariaId={ariaId}
+        popupId={popupId}
       >
         <div
-          id={props.id}
+          id={id}
           style={props.style}
           ref={this.saveRootRef}
           onBlur={this.onOuterBlur}
@@ -1547,7 +1555,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
             role="combobox"
             aria-autocomplete="list"
             aria-haspopup="true"
-            aria-controls={ariaId}
+            aria-controls={id}
             aria-expanded={realOpen}
             {...extraSelectionProps}
           >

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -53,7 +53,7 @@ export interface ISelectTriggerProps extends IDropdownMenuProps {
   dropdownRender: (menu: React.ReactNode, props: Partial<ISelectTriggerProps>) => React.ReactNode;
   onDropdownVisibleChange: (value: boolean) => void;
   getPopupContainer: renderSelect;
-  ariaId: string;
+  popupId: string;
   value: valueType;
   transitionName: string;
   animation: string;
@@ -90,7 +90,7 @@ export default class SelectTrigger extends React.Component<
     showAction: PropTypes.arrayOf(PropTypes.string),
     menuItemSelectedIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     dropdownRender: PropTypes.func,
-    ariaId: PropTypes.string,
+    popupId: PropTypes.string,
   };
 
   public saveDropdownMenuRef: (ref: any) => void;
@@ -136,13 +136,13 @@ export default class SelectTrigger extends React.Component<
   public getDropdownElement = (newProps: Partial<ISelectTriggerProps>) => {
     const props = this.props;
 
-    const { dropdownRender, ariaId } = props;
+    const { dropdownRender, popupId } = props;
 
     const menuNode = (
       <DropdownMenu
         ref={this.saveDropdownMenuRef}
         {...newProps}
-        ariaId={ariaId}
+        id={popupId}
         prefixCls={this.getDropdownPrefixCls()}
         onMenuSelect={props.onMenuSelect}
         onMenuDeselect={props.onMenuDeselect}

--- a/tests/__snapshots__/Select.combobox.spec.tsx.snap
+++ b/tests/__snapshots__/Select.combobox.spec.tsx.snap
@@ -6,7 +6,6 @@ exports[`Select.combobox allowClear renders correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -56,7 +55,6 @@ exports[`Select.combobox renders correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection

--- a/tests/__snapshots__/Select.multiple.spec.tsx.snap
+++ b/tests/__snapshots__/Select.multiple.spec.tsx.snap
@@ -6,7 +6,6 @@ exports[`Select.multiple allowClear renders correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -43,7 +42,6 @@ exports[`Select.multiple allowClear renders correctly 1`] = `
 
 exports[`Select.multiple render render animation 1`] = `
 <SelectTrigger
-  ariaId="test-uuid"
   backfillValue=""
   defaultActiveFirstOption={true}
   dropdownMatchSelectWidth={true}
@@ -57,6 +55,7 @@ exports[`Select.multiple render render animation 1`] = `
   onMenuSelect={[Function]}
   onPopupFocus={[Function]}
   options={Array []}
+  popupId="test-uuid__popup"
   prefixCls="rc-select"
   showAction={
     Array [
@@ -69,6 +68,7 @@ exports[`Select.multiple render render animation 1`] = `
 >
   <div
     className="rc-select rc-select-enabled"
+    id="test-uuid"
     onBlur={[Function]}
     onFocus={[Function]}
     onMouseDown={[Function]}
@@ -135,7 +135,6 @@ exports[`Select.multiple render truncates tags by maxTagCount 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -233,7 +232,6 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -333,7 +331,6 @@ exports[`Select.multiple render truncates tags by maxTagCount and show maxTagPla
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -433,7 +430,6 @@ exports[`Select.multiple render truncates tags by maxTagCount while maxTagCount 
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -487,7 +483,6 @@ exports[`Select.multiple render truncates values by maxTagTextLength 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection

--- a/tests/__snapshots__/Select.spec.tsx.snap
+++ b/tests/__snapshots__/Select.spec.tsx.snap
@@ -6,7 +6,6 @@ exports[`Select check title when label is a object 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -64,7 +63,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="rc-select-selection
@@ -111,7 +109,6 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--single rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        id=""
         style="overflow:auto;transform:translateZ(0)"
       >
         <ul
@@ -151,7 +148,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="rc-select-selection
@@ -198,7 +194,6 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--single rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        id=""
         style="overflow:auto;transform:translateZ(0)"
       >
         <ul
@@ -237,7 +232,6 @@ exports[`Select no search 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -275,7 +269,6 @@ exports[`Select render renders aria-attributes correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     aria-label="some-label"
@@ -352,7 +345,6 @@ exports[`Select render renders correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="antd-selection
@@ -427,7 +419,6 @@ exports[`Select render renders data-attributes correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="antd-selection
@@ -504,7 +495,6 @@ exports[`Select render renders disabeld select correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="antd-selection
@@ -581,7 +571,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="antd-selection
@@ -653,7 +642,6 @@ Array [
       class="antd-dropdown antd-dropdown--single antd-dropdown-placement-bottomLeft "
     >
       <div
-        id=""
         style="overflow:auto;transform:translateZ(0)"
       >
         <ul
@@ -733,7 +721,6 @@ exports[`Select render renders role prop correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="antd-selection
@@ -808,7 +795,6 @@ exports[`Select should contian falsy children 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -866,7 +852,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="rc-select-selection
@@ -919,7 +904,6 @@ Array [
           CUSTOM NODE
         </div>
         <div
-          id=""
           style="overflow:auto;transform:translateZ(0)"
         >
           <ul

--- a/tests/__snapshots__/Select.tags.spec.tsx.snap
+++ b/tests/__snapshots__/Select.tags.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
 <div>
   <div
     class="rc-select rc-select-open rc-select-focused rc-select-enabled"
+    id="test-uuid"
     style=""
   >
     <div
@@ -89,7 +90,7 @@ exports[`Select.tags OptGroup renders correctly 1`] = `
       style="left: -999px; top: -995px;"
     >
       <div
-        id="test-uuid"
+        id="test-uuid__popup"
         style="overflow: auto; transform: translateZ(0);"
       >
         <ul
@@ -160,6 +161,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 1`] = `
 <div>
   <div
     class="rc-select rc-select-open rc-select-focused rc-select-enabled"
+    id="test-uuid"
     style=""
   >
     <div
@@ -204,7 +206,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 1`] = `
       style="left: -999px; top: -995px;"
     >
       <div
-        id="test-uuid"
+        id="test-uuid__popup"
         style="overflow: auto; transform: translateZ(0);"
       >
         <ul
@@ -232,6 +234,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 2`] = `
 <div>
   <div
     class="rc-select rc-select-open rc-select-focused rc-select-enabled"
+    id="test-uuid"
     style=""
   >
     <div
@@ -297,7 +300,7 @@ exports[`Select.tags OptGroup renders inputValue correctly 2`] = `
       style="left: -999px; top: -995px;"
     >
       <div
-        id="test-uuid"
+        id="test-uuid__popup"
         style="overflow: auto; transform: translateZ(0);"
       >
         <ul
@@ -372,7 +375,6 @@ exports[`Select.tags allowClear renders correctly 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -409,7 +411,6 @@ exports[`Select.tags allowClear renders correctly 1`] = `
 
 exports[`Select.tags render render animation 1`] = `
 <SelectTrigger
-  ariaId="test-uuid"
   backfillValue=""
   defaultActiveFirstOption={true}
   dropdownMatchSelectWidth={true}
@@ -423,6 +424,7 @@ exports[`Select.tags render render animation 1`] = `
   onMenuSelect={[Function]}
   onPopupFocus={[Function]}
   options={Array []}
+  popupId="test-uuid__popup"
   prefixCls="rc-select"
   showAction={
     Array [
@@ -435,6 +437,7 @@ exports[`Select.tags render render animation 1`] = `
 >
   <div
     className="rc-select rc-select-enabled"
+    id="test-uuid"
     onBlur={[Function]}
     onFocus={[Function]}
     onMouseDown={[Function]}
@@ -501,7 +504,6 @@ exports[`Select.tags render truncates tags by maxTagCount 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -599,7 +601,6 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -699,7 +700,6 @@ exports[`Select.tags render truncates tags by maxTagCount and show maxTagPlaceho
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -799,7 +799,6 @@ exports[`Select.tags render truncates tags by maxTagCount while maxTagCount is 0
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -853,7 +852,6 @@ exports[`Select.tags render truncates values by maxTagTextLength 1`] = `
 >
   <div
     aria-autocomplete="list"
-    aria-controls=""
     aria-expanded="false"
     aria-haspopup="true"
     class="rc-select-selection
@@ -939,7 +937,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="rc-select-selection
@@ -999,7 +996,6 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--multiple rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        id=""
         style="overflow:auto;transform:translateZ(0)"
       >
         <ul
@@ -1039,7 +1035,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="rc-select-selection
@@ -1099,7 +1094,6 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--multiple rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        id=""
         style="overflow:auto;transform:translateZ(0)"
       >
         <ul
@@ -1148,7 +1142,6 @@ Array [
   >
     <div
       aria-autocomplete="list"
-      aria-controls=""
       aria-expanded="true"
       aria-haspopup="true"
       class="rc-select-selection
@@ -1186,7 +1179,6 @@ Array [
       class="rc-select-dropdown rc-select-dropdown--multiple rc-select-dropdown-placement-bottomLeft "
     >
       <div
-        id=""
         style="overflow:auto;transform:translateZ(0)"
       >
         <ul


### PR DESCRIPTION
remove additional rendering and produce a predictable result for testing.