### PR TITLE
Allow passing hideAction in props to rc-trigger

### DIFF
--- a/src/PropTypes.ts
+++ b/src/PropTypes.ts
@@ -75,6 +75,7 @@ export interface ISelectProps {
   tokenSeparators: string[];
   getInputElement: () => JSX.Element;
   showAction: string[];
+  hideAction: string[];
   clearIcon: ReactNode;
   inputIcon: ReactNode;
   removeIcon: ReactNode;
@@ -167,6 +168,7 @@ const SelectPropTypes = {
   tokenSeparators: PropTypes.arrayOf(PropTypes.string),
   getInputElement: PropTypes.func,
   showAction: PropTypes.arrayOf(PropTypes.string),
+  hideAction: PropTypes.arrayOf(PropTypes.string),
   clearIcon: PropTypes.node,
   inputIcon: PropTypes.node,
   removeIcon: PropTypes.node,

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1542,6 +1542,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
         onMenuDeselect={this.onMenuDeselect}
         onPopupScroll={props.onPopupScroll}
         showAction={props.showAction}
+        hideAction={props.hideAction}
         ref={this.saveSelectTriggerRef}
         menuItemSelectedIcon={props.menuItemSelectedIcon}
         dropdownRender={props.dropdownRender}

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -50,6 +50,7 @@ export interface ISelectTriggerProps extends IDropdownMenuProps {
   popupClassName: string;
   children: any;
   showAction: string[];
+  hideAction: string[];
   menuItemSelectedIcon: renderSelect;
   dropdownRender: (menu: React.ReactNode, props: Partial<ISelectTriggerProps>) => React.ReactNode;
   onDropdownVisibleChange: (value: boolean) => void;
@@ -89,6 +90,7 @@ export default class SelectTrigger extends React.Component<
     popupClassName: PropTypes.string,
     children: PropTypes.any,
     showAction: PropTypes.arrayOf(PropTypes.string),
+    hideAction: PropTypes.arrayOf(PropTypes.string),
     menuItemSelectedIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     dropdownRender: PropTypes.func,
     ariaId: PropTypes.string,
@@ -218,7 +220,7 @@ export default class SelectTrigger extends React.Component<
       <Trigger
         {...props}
         showAction={disabled ? [] : this.props.showAction}
-        hideAction={hideAction}
+        hideAction={this.props.hideAction || hideAction}
         ref={this.saveTriggerRef}
         popupPlacement="bottomLeft"
         builtinPlacements={BUILT_IN_PLACEMENTS}


### PR DESCRIPTION
Reopen #317 since not update for a while.

This pull request allows passing hideAction in rc-select to support hiding menu by mouseLeave/blur.

