### PR TITLE
Pass focus event to select blur functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ React.render(c, container);
 |backfill| whether backfill select option to search input (Only works in single and combobox mode) | Bool | false |
 |onChange | called when select an option or input value change(combobox) | function(value, option:Option/Array<Option>) | - |
 |onSearch | called when input changed | function | - |
-|onBlur | called when blur | function | - |
+|onBlur | called when blur | function(value, event) | - |
 |onFocus | called when focus | function | - |
 |onPopupScroll | called when menu is scrolled | function | - |
 |onSelect | called when a option is selected. param is option's value and option instance | Function(value, option:Option) | - |

--- a/examples/single.js
+++ b/examples/single.js
@@ -29,8 +29,8 @@ class Test extends React.Component {
     });
   };
 
-  onBlur = v => {
-    console.log('onBlur', v);
+  onBlur = (value, e) => {
+    console.log('onBlur', value, e);
   };
 
   onFocus = () => {

--- a/src/PropTypes.ts
+++ b/src/PropTypes.ts
@@ -52,7 +52,7 @@ export interface ISelectProps {
   defaultOpen: boolean;
   inputValue: string;
   onChange: (value: valueType, option: JSX.Element | JSX.Element[]) => void;
-  onBlur: emptyFunction;
+  onBlur: (value: valueType, FocusEvent?) => void;
   onFocus: emptyFunction;
   onSelect: (value: valueType, option: JSX.Element | JSX.Element[]) => void;
   onSearch: (value: string) => void;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -563,7 +563,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
       }
       this.setOpenState(false);
       if (props.onBlur) {
-        props.onBlur(this.getVLForOnChange(value as valueType));
+        props.onBlur(this.getVLForOnChange(value as valueType), e);
       }
     }, 10);
   };


### PR DESCRIPTION
I'm using ant design and it's using this select component.

We really need the `event` variable once we're blurring it, so we can stop propagation. I thought perhaps I'm not the only one and this PR could be helpful.

I'm not too experienced in creating PRs, so I hope if everything is okay and apologise if not.