### PR TITLE
性能调优，将获取offsetwidth的行为放置requestAnimationFrame中

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/classnames": "^2.2.6",
     "@types/enzyme": "^3.1.15",
+    "@types/raf": "^3.4.0",
     "@types/react": "^16.7.17",
     "@types/react-dom": "^16.0.11",
     "@types/warning": "^3.0.0",

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -9,6 +9,12 @@ import { isSingleMode, saveRef } from './util';
 
 Trigger.displayName = 'Trigger';
 
+const raf = window.requestAnimationFrame
+  || window.webkitRequestAnimationFrame
+  || window.mozRequestAnimationFrame
+  || window.msRequestAnimationFrame
+  || function(cb) { return setTimeout(cb, 16); };
+
 const BUILT_IN_PLACEMENTS = {
   bottomLeft: {
     points: ['tl', 'bl'],
@@ -111,11 +117,11 @@ export default class SelectTrigger extends React.Component<
   }
 
   public componentDidMount() {
-    this.setDropdownWidth();
+    raf(this.setDropdownWidth);
   }
 
   public componentDidUpdate() {
-    this.setDropdownWidth();
+    raf(this.setDropdownWidth);
   }
 
   public setDropdownWidth = () => {

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -121,15 +121,11 @@ export default class SelectTrigger extends React.Component<
   }
 
   public componentWillUnmount() {
-    if (this.rafInstance) {
-      raf.cancel(this.rafInstance);
-    }
+    this.cancelRafInstance();
   }
 
   public setDropdownWidth = () => {
-    if (this.rafInstance) {
-      raf.cancel(this.rafInstance);
-    }
+    this.cancelRafInstance();
     this.rafInstance = raf(() => {
       const dom = ReactDOM.findDOMNode(this) as HTMLDivElement;
       const width = dom.offsetWidth;
@@ -137,6 +133,12 @@ export default class SelectTrigger extends React.Component<
         this.setState({ dropdownWidth: width });
       }
     });
+  };
+
+  public cancelRafInstance = () => {
+    if (this.rafInstance) {
+      raf.cancel(this.rafInstance);
+    }
   };
 
   public getInnerMenu = () => {

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -99,9 +99,7 @@ export default class SelectTrigger extends React.Component<
   public saveTriggerRef: (ref: any) => void;
   public dropdownMenuRef: DropdownMenu | null = null;
   public triggerRef: any;
-  public rafInstance: {
-    cancel: () => void;
-  } = { cancel: () => null };
+  public rafInstance: number | null = null;
 
   constructor(props: Partial<ISelectTriggerProps>) {
     super(props);
@@ -123,14 +121,14 @@ export default class SelectTrigger extends React.Component<
   }
 
   public componentWillUnmount() {
-    if (this.rafInstance && this.rafInstance.cancel) {
-      this.rafInstance.cancel();
+    if (this.rafInstance) {
+      raf.cancel(this.rafInstance);
     }
   }
 
   public setDropdownWidth = () => {
-    if (this.rafInstance && this.rafInstance.cancel) {
-      this.rafInstance.cancel();
+    if (this.rafInstance) {
+      raf.cancel(this.rafInstance);
     }
     this.rafInstance = raf(() => {
       const dom = ReactDOM.findDOMNode(this) as HTMLDivElement;

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -129,6 +129,9 @@ export default class SelectTrigger extends React.Component<
   }
 
   public setDropdownWidth = () => {
+    if (this.rafInstance && this.rafInstance.cancel) {
+      this.rafInstance.cancel();
+    }
     this.rafInstance = raf(() => {
       const dom = ReactDOM.findDOMNode(this) as HTMLDivElement;
       const width = dom.offsetWidth;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,6 +12,4 @@ declare module 'rc-util/lib/KeyCode';
 
 declare module 'dom-scroll-into-view';
 
-declare module 'raf';
-
 declare module 'rc-trigger';


### PR DESCRIPTION
### 这个变动的性质是

- [x] 其他改动

### 需求背景
  
> 1. 针对使用antd表格，在大量数据下的调优
> 2. 表格下的分页使用了该控件，存在forced reflow的问题
![image](https://user-images.githubusercontent.com/8839694/55710970-58645580-5a1e-11e9-990f-47caae7cf1d4.png)

  
### 实现方案和 API
  
> 将获取offsetwidth的行为放置requestAnimationFrame中

```
const raf = window.requestAnimationFrame
  || window.webkitRequestAnimationFrame
  || window.mozRequestAnimationFrame
  || window.msRequestAnimationFrame
  || function(cb) { return setTimeout(cb, 16); };

function componentDidMount() {
  raf(this.setDropdownWidth);
}

function componentDidUpdate() {
  raf(this.setDropdownWidth);
}
```

  
### 对用户的影响和可能的风险

> 无明显影响

#### changelog

> 性能优化，将获取offsetwidth的行为放置requestAnimationFrame中

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划

无