### PR TITLE
fix: Don't trigger onSearch when option is selected

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "name": "rc-tree",
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "distDir": "build" }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "coverage": "rc-tools run test --coverage",
     "pre-commit": "rc-tools run pre-commit",
     "storybook": "rc-tools run storybook",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "now-build": "npm run build"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.6",

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -323,7 +323,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
       if (nextValue !== undefined) {
         this.fireChange(nextValue);
       }
-      this.setOpenState(false, true);
+      this.setOpenState(false, { needFocus: true });
       this.setInputValue('', false);
       return;
     }
@@ -446,11 +446,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
         lastValue === selectedValue &&
         selectedValue !== this.state.backfillValue
       ) {
-        this.setOpenState(false, true, false);
+        this.setOpenState(false, { needFocus: true, fireSearch: false });
         return;
       }
       value = [selectedValue];
-      this.setOpenState(false, true, false);
+      this.setOpenState(false, { needFocus: true, fireSearch: false });
     }
 
     this.fireChange(value);
@@ -479,7 +479,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     e.stopPropagation();
     e.preventDefault();
     if (!this.props.disabled) {
-      this.setOpenState(!this.state.open, !this.state.open);
+      this.setOpenState(!this.state.open, { needFocus: !this.state.open });
     }
   };
 
@@ -581,7 +581,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
       if (value.length) {
         this.fireChange([]);
       }
-      this.setOpenState(false, true);
+      this.setOpenState(false, { needFocus: true });
       if (inputValue) {
         this.setInputValue('');
       }
@@ -778,7 +778,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     }
   };
 
-  public setOpenState = (open: boolean, needFocus?: boolean, fireChange?: boolean) => {
+  public setOpenState = (
+    open: boolean,
+    config: { needFocus?: boolean; fireSearch?: boolean } = {},
+  ) => {
+    const { needFocus, fireSearch } = config;
     const props = this.props;
     const state = this.state;
 
@@ -797,7 +801,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     };
     // clear search input value when open is false in singleMode.
     if (!open && isSingleMode(props) && props.showSearch) {
-      this.setInputValue('', fireChange);
+      this.setInputValue('', fireSearch);
     }
     if (!open) {
       this.maybeFocus(open, !!needFocus);

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -446,18 +446,18 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
         lastValue === selectedValue &&
         selectedValue !== this.state.backfillValue
       ) {
-        this.setOpenState(false, true);
+        this.setOpenState(false, true, false);
         return;
       }
       value = [selectedValue];
-      this.setOpenState(false, true);
+      this.setOpenState(false, true, false);
     }
 
     this.fireChange(value);
     const inputValue = isCombobox(props) ? getPropValue(item, props.optionLabelProp) : '';
 
     if (props.autoClearSearchValue) {
-      this.setInputValue(inputValue);
+      this.setInputValue(inputValue, false);
     }
   };
 
@@ -778,7 +778,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     }
   };
 
-  public setOpenState = (open: boolean, needFocus?: boolean) => {
+  public setOpenState = (open: boolean, needFocus?: boolean, fireChange?: boolean) => {
     const props = this.props;
     const state = this.state;
 
@@ -797,7 +797,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     };
     // clear search input value when open is false in singleMode.
     if (!open && isSingleMode(props) && props.showSearch) {
-      this.setInputValue('');
+      this.setInputValue('', fireChange);
     }
     if (!open) {
       this.maybeFocus(open, !!needFocus);

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -412,11 +412,21 @@ describe('Select', () => {
     );
     wrapper.find('input').simulate('change', { target: { value: '1' } });
     expect(handleSearch).toHaveBeenCalledTimes(1);
+
+    // Not fire onSearch when value selected
+    // https://github.com/ant-design/ant-design/pull/16235#issuecomment-487506523
     wrapper
       .find('MenuItem')
       .first()
       .simulate('click');
+    expect(handleSearch).toHaveBeenCalledTimes(1);
+
+    // Should trigger onBlur
+    wrapper.find('input').simulate('change', { target: { value: '3' } });
     expect(handleSearch).toHaveBeenCalledTimes(2);
+    wrapper.find('.rc-select').simulate('blur');
+    jest.runAllTimers();
+    expect(handleSearch).toHaveBeenCalledTimes(3);
   });
 
   describe('focus', () => {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/16377
ref: https://github.com/ant-design/ant-design/pull/16235#issuecomment-487506523

-----------------

hot fix：
内部有几个分支会触发 search change，这里给 `setOpenState` 额外添加了一个参数用于处理 select 时不要触发 onSearch。

将来需要重构将 inputChange 逻辑从 popup 开关里抽出来。