### PR TITLE
fix(Select.tsx): 组件受控时，使用onSearch监控输入事件，不能输入中文。

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -858,12 +858,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     const { onSearch } = this.props;
     if (inputValue !== this.state.inputValue) {
       this.setState(prevState => {
-        // Additional check if `inputValue` changed in latest state.
-        if (fireSearch && inputValue !== prevState.inputValue && onSearch) {
-          onSearch(inputValue);
-        }
         return { inputValue };
       }, this.forcePopupAlign);
+      if (fireSearch && onSearch) {
+        onSearch(inputValue);
+      }
     }
   };
 


### PR DESCRIPTION
setState function updater里调用onSearch，当前子组件和父组件生命周期调用顺序如下：当前子组件render -> 父组件render ->
当前子组件render，因为当前子组件先render一遍，而getDerivedStateFromProps()中，inputValue是从Props获取值的，inputValue会被设置两次值，并且第一次设置会把IMF最后一个输入字符去掉，这样input
value会被设置两次不同的值，导致不能输入中文。

issue:[https://github.com/ant-design/ant-design/issues/18230#issue-479632574](https://github.com/ant-design/ant-design/issues/18230#issue-479632574)