### PR TITLE
Allow limiting number of items in the dropdown 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ React.render(c, container);
 | menuItemSelectedIcon | specify the remove icon | ReactNode \| (props: MenuItemProps) => ReactNode | - |
 | dropdownRender | render custom dropdown menu | (menu: React.Node, props: MenuProps) => ReactNode | - |
 | loading | show loading icon in arrow | Boolean | false |
+| dropdownLimit | limit the number of items in the dropdown | Number | - |
 
 ### Methods
 

--- a/examples/multiple.js
+++ b/examples/multiple.js
@@ -18,6 +18,7 @@ class Test extends React.Component {
     useAnim: 0,
     showArrow: 0,
     loading: 0,
+    dropdownLimit: 0,
     value: ['a10'],
   };
 
@@ -54,8 +55,14 @@ class Test extends React.Component {
     });
   };
 
+  dropdownLimit = e => {
+    this.setState({
+      dropdownLimit: e.target.checked * 5,
+    });
+  };
+
   render() {
-    const { useAnim, showArrow, loading, value } = this.state;
+    const { useAnim, showArrow, loading, value, dropdownLimit } = this.state;
     const dropdownMenuStyle = {
       maxHeight: 200,
     };
@@ -80,6 +87,17 @@ class Test extends React.Component {
             <input id="loading" checked={loading} type="checkbox" onChange={this.loading} />
           </label>
         </p>
+        <p>
+          <label htmlFor="dropdownLimit">
+            dropdownLimit
+            <input
+              id="dropdownLimit"
+              checked={dropdownLimit}
+              type="checkbox"
+              onChange={this.dropdownLimit}
+            />
+          </label>
+        </p>
 
         <div style={{ width: 300 }}>
           <Select
@@ -101,6 +119,7 @@ class Test extends React.Component {
             onFocus={() => console.log('focus')}
             onBlur={v => console.log('blur', v)}
             tokenSeparators={[' ', ',']}
+            dropdownLimit={dropdownLimit}
           >
             {children}
           </Select>

--- a/src/PropTypes.ts
+++ b/src/PropTypes.ts
@@ -87,6 +87,7 @@ export interface ISelectProps {
   dropdownClassName: string;
   dropdownMatchSelectWidth: boolean;
   dropdownMenuStyle: React.CSSProperties;
+  dropdownLimit: string | number;
   notFoundContent: string | false;
   tabIndex: string | number;
 }

--- a/src/PropTypes.ts
+++ b/src/PropTypes.ts
@@ -87,7 +87,7 @@ export interface ISelectProps {
   dropdownClassName: string;
   dropdownMatchSelectWidth: boolean;
   dropdownMenuStyle: React.CSSProperties;
-  dropdownLimit: string | number;
+  dropdownLimit: number;
   notFoundContent: string | false;
   tabIndex: string | number;
 }

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -85,6 +85,7 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     dropdownMatchSelectWidth: true,
     dropdownStyle: {},
     dropdownMenuStyle: {},
+    dropdownLimit: 0,
     optionFilterProp: 'value',
     optionLabelProp: 'value',
     notFoundContent: 'Not Found',
@@ -1196,6 +1197,8 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
     const props = this.props;
     const { inputValue } = this.state;
     const tags = props.tags;
+    const limit = props.dropdownLimit;
+    let currentMenuCount = 0;
     React.Children.forEach(children, child => {
       if (!child) {
         return;
@@ -1259,7 +1262,11 @@ class Select extends React.Component<Partial<ISelectProps>, ISelectState> {
 
       validateOptionValue(childValue, this.props);
 
-      if (this.filterOption(inputValue as string, child as React.ReactElement<any>)) {
+      if (
+        (!limit || currentMenuCount < limit) &&
+        this.filterOption(inputValue as string, child as React.ReactElement<any>)
+      ) {
+        currentMenuCount = currentMenuCount + 1;
         const menuItem = (
           <MenuItem
             style={UNSELECTABLE_STYLE}

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -1194,4 +1194,21 @@ describe('Select', () => {
       expect(onSelect).toBeCalledWith('1', expect.anything());
     }
   });
+
+  it('limits dropdown item count when explicitly set', () => {
+    const wrapper = mount(
+      <Select multiple={true} value={['']} open={true}>
+        <Option value={1}>1</Option>
+        <Option value={2}>2</Option>
+      </Select>,
+    );
+
+    expect(wrapper.find('SelectTrigger').prop('options')).toHaveLength(2);
+
+    // multiple=true showArrow=true  arrow do have
+    wrapper.setProps({
+      dropdownLimit: 1,
+    });
+    expect(wrapper.find('SelectTrigger').prop('options')).toHaveLength(1);
+  });
 });

--- a/tests/Select.spec.tsx
+++ b/tests/Select.spec.tsx
@@ -1205,7 +1205,6 @@ describe('Select', () => {
 
     expect(wrapper.find('SelectTrigger').prop('options')).toHaveLength(2);
 
-    // multiple=true showArrow=true  arrow do have
     wrapper.setProps({
       dropdownLimit: 1,
     });


### PR DESCRIPTION
In some use cases the number of options passed to rc-select can be very
large. The performance of rendering the dropdown with a large number of
items can be very poor. The dropdownLimit option if set will prevent
rendering of any matched options beyond the limit, greatly improving
performance. The user experience is not greatly diminished, as they are
presented with a smaller number of choices at once, and can narrow down
the choices by typing more, similar to a typeahead system.