### PR TITLE
Set 'prevValue' to 'outOption'

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -409,7 +409,7 @@ export default function generateSelector<
           })
         : newValue) as SingleType<ValueType>;
 
-      const outOption = findValueOption([newValue], mergedFlattenOptions)[0];
+      const outOption = { findValueOption([newValue], mergedFlattenOptions)[0], prevValue: baseValue };
 
       if (isSelect && onSelect) {
         onSelect(selectValue, outOption);

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -409,7 +409,7 @@ export default function generateSelector<
           })
         : newValue) as SingleType<ValueType>;
 
-      const outOption = { findValueOption([newValue], mergedFlattenOptions)[0], prevValue: baseValue };
+      const outOption = { ...findValueOption([newValue], mergedFlattenOptions)[0], prevValue: baseValue };
 
       if (isSelect && onSelect) {
         onSelect(selectValue, outOption);


### PR DESCRIPTION
@zombieJ 能否考虑设置上次的值到outOption中。当是form中有多个相同的下拉框时，onSelect 或 onChange 中的option属性中没有包含上次的值，就不能取消上次的值disable属性。