### PR TITLE
fix: Typescript type declaration of OptionProps

### DIFF
--- a/src/Option.tsx
+++ b/src/Option.tsx
@@ -1,9 +1,12 @@
 /* istanbul ignore file */
 import * as React from 'react';
-import { OptionData } from './interface';
+import { OptionCoreData } from './interface';
 
-export interface OptionProps extends Omit<OptionData, 'label'> {
+export interface OptionProps extends Omit<OptionCoreData, 'label'> {
   children: React.ReactNode;
+
+  /** Save for customize data */
+  [prop: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export interface OptionFC extends React.FC<OptionProps> {

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -8,7 +8,7 @@ export type RenderNode = React.ReactNode | ((props: any) => React.ReactNode);
 export type Mode = 'multiple' | 'tags' | 'combobox';
 
 // ======================== Option ========================
-export interface OptionData {
+export interface OptionCoreData {
   key?: Key;
   disabled?: boolean;
   value: Key;
@@ -18,7 +18,9 @@ export interface OptionData {
   label?: React.ReactNode;
   /** @deprecated Only works when use `children` as option data */
   children?: React.ReactNode;
+}
 
+export interface OptionData extends OptionCoreData {
   /** Save for customize data */
   [prop: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }


### PR DESCRIPTION
Due to the mix of `Omit` and `keyof` for mapped type, the type declaration of `OptionProps` in current beta version(10.x) fails to work expectedly.

Try to explain this.

```ts
// declaration of Typescript's built-in `Omit` utility
type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
```

```ts
interface Foo {
   bar: string;
   baz: number;
   [key: string]: any;
}
type FooKey = keyof Foo; // string | number

type FooKeyExclude = Exclude<FooKey, 'bar'>; // string | number

/**
* `FooOmit` will be
* ```ts
* {
*   [x: string]: any;
*   [x: number]: any;
* }
* ```
*/
type FooOmit = Pick<Foo, FooKeyExclude>;
```

The `OptionProps` of current version ships with the same fault.

```ts
// path: `$PROJECT_ROOT/src/interface/index.ts`
export interface OptionData {
  /* some properties ... */

  /** Save for customize data */
  [prop: string]: any; 
}

// path: `$PROJECT_ROOT/src/Option.tsx`
export interface OptionProps extends Omit<OptionData, 'label'> {
  children: React.ReactNode;
}

// `Omit<OptionCoreData, 'label'>` works unexpectedly, thus it hides all named properties of `OptionData` interface.
```