### PR TITLE
chore: No popup when null empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ es/
 package-lock.json
 src/*.js
 src/*.map
-.prettierrc
 tslint.json
 tsconfig.test.json
 .prettierignore

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "endOfLine": "lf",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -30,7 +30,12 @@ import {
   SelectSource,
 } from './interface/generator';
 import { OptionListProps, RefOptionListProps } from './OptionList';
-import { toInnerValue, toOuterValues, removeLastEnabledValue, getUUID } from './utils/commonUtil';
+import {
+  toInnerValue,
+  toOuterValues,
+  removeLastEnabledValue,
+  getUUID,
+} from './utils/commonUtil';
 import TransBtn from './TransBtn';
 import useLock from './hooks/useLock';
 import useDelayReset from './hooks/useDelayReset';
@@ -53,7 +58,8 @@ export interface RefSelectProps {
   blur: () => void;
 }
 
-export interface SelectProps<OptionsType extends object[], ValueType> extends React.AriaAttributes {
+export interface SelectProps<OptionsType extends object[], ValueType>
+  extends React.AriaAttributes {
   prefixCls?: string;
   id?: string;
   className?: string;
@@ -117,7 +123,9 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   optionLabelProp?: string;
   maxTagTextLength?: number;
   maxTagCount?: number;
-  maxTagPlaceholder?: React.ReactNode | ((omittedValues: LabelValueType[]) => React.ReactNode);
+  maxTagPlaceholder?:
+    | React.ReactNode
+    | ((omittedValues: LabelValueType[]) => React.ReactNode);
   tokenSeparators?: string[];
   showAction?: ('focus' | 'click')[];
   tabIndex?: number;
@@ -127,11 +135,20 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   onPopupScroll?: React.UIEventHandler<HTMLDivElement>;
   onDropdownVisibleChange?: (open: boolean) => void;
-  onSelect?: (value: SingleType<ValueType>, option: OptionsType[number]) => void;
-  onDeselect?: (value: SingleType<ValueType>, option: OptionsType[number]) => void;
+  onSelect?: (
+    value: SingleType<ValueType>,
+    option: OptionsType[number],
+  ) => void;
+  onDeselect?: (
+    value: SingleType<ValueType>,
+    option: OptionsType[number],
+  ) => void;
   onInputKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   onClick?: React.MouseEventHandler;
-  onChange?: (value: ValueType, option: OptionsType[number] | OptionsType) => void;
+  onChange?: (
+    value: ValueType,
+    option: OptionsType[number] | OptionsType,
+  ) => void;
   onBlur?: React.FocusEventHandler<HTMLElement>;
   onFocus?: React.FocusEventHandler<HTMLElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
@@ -151,7 +168,11 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
     onClear?: OnClear;
     skipTriggerChange?: boolean;
     skipTriggerSelect?: boolean;
-    onRawSelect?: (value: RawValueType, option: OptionsType[number], source: SelectSource) => void;
+    onRawSelect?: (
+      value: RawValueType,
+      option: OptionsType[number],
+      source: SelectSource,
+    ) => void;
     onRawDeselect?: (
       value: RawValueType,
       option: OptionsType[number],
@@ -173,7 +194,10 @@ export interface GenerateConfig<OptionsType extends object[]> {
   /** Convert jsx tree into `OptionsType` */
   convertChildrenToData: (children: React.ReactNode) => OptionsType;
   /** Flatten nest options into raw option list */
-  flattenOptions: (options: OptionsType, props: any) => FlattenOptionsType<OptionsType>;
+  flattenOptions: (
+    options: OptionsType,
+    props: any,
+  ) => FlattenOptionsType<OptionsType>;
   /** Convert single raw value into { label, value } format. Will be called by each value */
   getLabeledValue: GetLabeledValue<FlattenOptionsType<OptionsType>>;
   filterOptions: FilterOptions<OptionsType>;
@@ -182,7 +206,10 @@ export interface GenerateConfig<OptionsType extends object[]> {
     options: FlattenOptionsType<OptionsType>,
   ) => OptionsType;
   /** Check if a value is disabled */
-  isValueDisabled: (value: RawValueType, options: FlattenOptionsType<OptionsType>) => boolean;
+  isValueDisabled: (
+    value: RawValueType,
+    options: FlattenOptionsType<OptionsType>,
+  ) => boolean;
   warningProps?: (props: any) => void;
   fillOptionsWithMissingValue?: (
     options: OptionsType,
@@ -341,8 +368,11 @@ export default function generateSelector<
     }));
 
     // ============================= Value ==============================
-    const [innerValue, setInnerValue] = React.useState<ValueType>(value || defaultValue);
-    const baseValue = value !== undefined && value !== null ? value : innerValue;
+    const [innerValue, setInnerValue] = React.useState<ValueType>(
+      value || defaultValue,
+    );
+    const baseValue =
+      value !== undefined && value !== null ? value : innerValue;
 
     /** Unique raw values */
     const mergedRawValue = React.useMemo<RawValueType[]>(
@@ -354,9 +384,10 @@ export default function generateSelector<
       [baseValue, mergedLabelInValue],
     );
     /** We cache a set of raw values to speed up check */
-    const rawValues = React.useMemo<Set<RawValueType>>(() => new Set(mergedRawValue), [
-      mergedRawValue,
-    ]);
+    const rawValues = React.useMemo<Set<RawValueType>>(
+      () => new Set(mergedRawValue),
+      [mergedRawValue],
+    );
 
     // ============================= Option =============================
     // Set by option list active, it will merge into search input when mode is `combobox`
@@ -401,11 +432,21 @@ export default function generateSelector<
       if (!mergedSearchValue) {
         return [...mergedOptions] as OptionsType;
       }
-      const filteredOptions: OptionsType = filterOptions(mergedSearchValue, mergedOptions, {
-        optionFilterProp,
-        filterOption: mode === 'combobox' && filterOption === undefined ? () => true : filterOption,
-      });
-      if (mode === 'tags' && filteredOptions.every(opt => opt.value !== mergedSearchValue)) {
+      const filteredOptions: OptionsType = filterOptions(
+        mergedSearchValue,
+        mergedOptions,
+        {
+          optionFilterProp,
+          filterOption:
+            mode === 'combobox' && filterOption === undefined
+              ? () => true
+              : filterOption,
+        },
+      );
+      if (
+        mode === 'tags' &&
+        filteredOptions.every(opt => opt.value !== mergedSearchValue)
+      ) {
         filteredOptions.unshift({
           value: mergedSearchValue,
           label: mergedSearchValue,
@@ -416,10 +457,11 @@ export default function generateSelector<
       return filteredOptions;
     }, [mergedOptions, mergedSearchValue, mode]);
 
-    const displayFlattenOptions: FlattenOptionsType<OptionsType> = React.useMemo(
-      () => flattenOptions(displayOptions, props),
-      [displayOptions],
-    );
+    const displayFlattenOptions: FlattenOptionsType<
+      OptionsType
+    > = React.useMemo(() => flattenOptions(displayOptions, props), [
+      displayOptions,
+    ]);
 
     // ============================ Selector ============================
     const displayValues = React.useMemo<DisplayLabelValueType[]>(
@@ -440,7 +482,11 @@ export default function generateSelector<
       [baseValue, mergedOptions],
     );
 
-    const triggerSelect = (newValue: RawValueType, isSelect: boolean, source: SelectSource) => {
+    const triggerSelect = (
+      newValue: RawValueType,
+      isSelect: boolean,
+      source: SelectSource,
+    ) => {
       const outOption = findValueOption([newValue], mergedFlattenOptions)[0];
 
       if (!internalProps.skipTriggerSelect) {
@@ -476,15 +522,20 @@ export default function generateSelector<
         return;
       }
 
-      const outValues = toOuterValues<FlattenOptionsType<OptionsType>>(Array.from(newRawValues), {
-        labelInValue: mergedLabelInValue,
-        options: mergedFlattenOptions,
-        getLabeledValue,
-        prevValue: baseValue,
-        optionLabelProp: mergedOptionLabelProp,
-      });
+      const outValues = toOuterValues<FlattenOptionsType<OptionsType>>(
+        Array.from(newRawValues),
+        {
+          labelInValue: mergedLabelInValue,
+          options: mergedFlattenOptions,
+          getLabeledValue,
+          prevValue: baseValue,
+          optionLabelProp: mergedOptionLabelProp,
+        },
+      );
 
-      const outValue: ValueType = (isMultiple ? outValues : outValues[0]) as ValueType;
+      const outValue: ValueType = (isMultiple
+        ? outValues
+        : outValues[0]) as ValueType;
       // Skip trigger if prev & current value is both empty
       if (onChange && (mergedRawValue.length !== 0 || outValues.length !== 0)) {
         const outOptions = findValueOption(newRawValues, mergedFlattenOptions);
@@ -497,7 +548,10 @@ export default function generateSelector<
 
     const onInternalSelect = (
       newValue: RawValueType,
-      { selected, source }: { selected: boolean; source: 'option' | 'selection' },
+      {
+        selected,
+        source,
+      }: { selected: boolean; source: 'option' | 'selection' },
     ) => {
       if (disabled) {
         return;
@@ -518,7 +572,10 @@ export default function generateSelector<
       }
 
       // Multiple always trigger change and single should change if value changed
-      if (isMultiple || (!isMultiple && Array.from(mergedRawValue)[0] !== newValue)) {
+      if (
+        isMultiple ||
+        (!isMultiple && Array.from(mergedRawValue)[0] !== newValue)
+      ) {
         triggerChange(Array.from(newRawValue));
       }
 
@@ -535,11 +592,17 @@ export default function generateSelector<
       }
     };
 
-    const onInternalOptionSelect = (newValue: RawValueType, info: { selected: boolean }) => {
+    const onInternalOptionSelect = (
+      newValue: RawValueType,
+      info: { selected: boolean },
+    ) => {
       onInternalSelect(newValue, { ...info, source: 'option' });
     };
 
-    const onInternalSelectionSelect = (newValue: RawValueType, info: { selected: boolean }) => {
+    const onInternalSelectionSelect = (
+      newValue: RawValueType,
+      info: { selected: boolean },
+    ) => {
       onInternalSelect(newValue, { ...info, source: 'selection' });
     };
 
@@ -552,8 +615,8 @@ export default function generateSelector<
     const [innerOpen, setInnerOpen] = React.useState<boolean>(defaultOpen);
     let mergedOpen: boolean = open !== undefined ? open : innerOpen;
 
-    // Not trigger `open` in `combobox` when `notFoundContent` is empty
-    if (mergedOpen && mode === 'combobox' && !notFoundContent && !displayOptions.length) {
+    // Not trigger `open` when `notFoundContent` is empty
+    if (mergedOpen && !notFoundContent && !displayOptions.length) {
       mergedOpen = false;
     }
 
@@ -576,7 +639,10 @@ export default function generateSelector<
       setActiveValue(null);
 
       // Check if match the `tokenSeparators`
-      const patchLabels: string[] = getSeparatedContent(searchText, tokenSeparators);
+      const patchLabels: string[] = getSeparatedContent(
+        searchText,
+        tokenSeparators,
+      );
       let patchRawValues: RawValueType[] = patchLabels;
 
       if (mode === 'combobox') {
@@ -640,7 +706,10 @@ export default function generateSelector<
     const clearLock = getClearLock();
 
     // KeyDown
-    const onInternalKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event, ...rest) => {
+    const onInternalKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (
+      event,
+      ...rest
+    ) => {
       const { which } = event;
 
       // We only manage open state here, close logic should handle by list component
@@ -658,7 +727,10 @@ export default function generateSelector<
         !mergedSearchValue &&
         mergedRawValue.length
       ) {
-        const removeInfo = removeLastEnabledValue(displayValues, mergedRawValue);
+        const removeInfo = removeLastEnabledValue(
+          displayValues,
+          mergedRawValue,
+        );
 
         if (removeInfo.removedValue !== null) {
           triggerChange(removeInfo.values);
@@ -676,7 +748,10 @@ export default function generateSelector<
     };
 
     // KeyUp
-    const onInternalKeyUp: React.KeyboardEventHandler<HTMLDivElement> = (event, ...rest) => {
+    const onInternalKeyUp: React.KeyboardEventHandler<HTMLDivElement> = (
+      event,
+      ...rest
+    ) => {
       if (mergedOpen && listRef.current) {
         listRef.current.onKeyUp(event, ...rest);
       }
@@ -691,7 +766,9 @@ export default function generateSelector<
     /** Record real focus status */
     const focusRef = React.useRef<boolean>(false);
 
-    const onContainerFocus: React.FocusEventHandler<HTMLElement> = (...args) => {
+    const onContainerFocus: React.FocusEventHandler<HTMLElement> = (
+      ...args
+    ) => {
       setMockFocused(true);
 
       if (!disabled) {
@@ -722,7 +799,9 @@ export default function generateSelector<
         // `tags` mode should move `searchValue` into values
         if (mode === 'tags') {
           triggerSearch('', false);
-          triggerChange(Array.from(new Set([...mergedRawValue, mergedSearchValue])));
+          triggerChange(
+            Array.from(new Set([...mergedRawValue, mergedSearchValue])),
+          );
         } else if (mode === 'multiple') {
           // `multiple` mode only clean the search value but not trigger event
           setInnerSearchValue('');
@@ -734,7 +813,10 @@ export default function generateSelector<
       }
     };
 
-    const onInternalMouseDown: React.MouseEventHandler<HTMLDivElement> = (event, ...restArgs) => {
+    const onInternalMouseDown: React.MouseEventHandler<HTMLDivElement> = (
+      event,
+      ...restArgs
+    ) => {
       const { target } = event;
       const popupElement: HTMLDivElement =
         triggerRef.current && triggerRef.current.getPopupElement();
@@ -755,9 +837,13 @@ export default function generateSelector<
     };
 
     // ========================= Accessibility ==========================
-    const [accessibilityIndex, setAccessibilityIndex] = React.useState<number>(0);
+    const [accessibilityIndex, setAccessibilityIndex] = React.useState<number>(
+      0,
+    );
     const mergedDefaultActiveFirstOption =
-      defaultActiveFirstOption !== undefined ? defaultActiveFirstOption : mode !== 'combobox';
+      defaultActiveFirstOption !== undefined
+        ? defaultActiveFirstOption
+        : mode !== 'combobox';
 
     const onActiveValue = (active: RawValueType, index: number) => {
       setAccessibilityIndex(index);
@@ -814,7 +900,11 @@ export default function generateSelector<
       triggerSearch('', false);
     };
 
-    if (!disabled && allowClear && (mergedRawValue.length || mergedSearchValue)) {
+    if (
+      !disabled &&
+      allowClear &&
+      (mergedRawValue.length || mergedSearchValue)
+    ) {
       clearNode = (
         <TransBtn
           className={`${prefixCls}-clear`}
@@ -828,7 +918,9 @@ export default function generateSelector<
 
     // ============================= Arrow ==============================
     const mergedShowArrow =
-      showArrow !== undefined ? showArrow : loading || (!isMultiple && mode !== 'combobox');
+      showArrow !== undefined
+        ? showArrow
+        : loading || (!isMultiple && mode !== 'combobox');
     let arrowNode: React.ReactNode;
 
     if (mergedShowArrow) {
@@ -881,7 +973,13 @@ export default function generateSelector<
       >
         {mockFocused && !mergedOpen && (
           <span
-            style={{ width: 0, height: 0, display: 'flex', overflow: 'hidden', opacity: 0 }}
+            style={{
+              width: 0,
+              height: 0,
+              display: 'flex',
+              overflow: 'hidden',
+              opacity: 0,
+            }}
             aria-live="polite"
           >
             {/* Merge into one string to make screen reader work as expect */}
@@ -935,7 +1033,9 @@ export default function generateSelector<
 
   // Ref of Select
   type RefSelectFuncType = typeof RefSelectFunc;
-  const RefSelect = ((React.forwardRef as unknown) as RefSelectFuncType)(Select);
+  const RefSelect = ((React.forwardRef as unknown) as RefSelectFuncType)(
+    Select,
+  );
 
   return RefSelect;
 }

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -169,7 +169,11 @@ describe('Select.Basic', () => {
 
     toggleOpen(wrapper);
     expect(
-      wrapper.find('.rc-select-item-option-selected div.rc-select-item-option-content').text(),
+      wrapper
+        .find(
+          '.rc-select-item-option-selected div.rc-select-item-option-content',
+        )
+        .text(),
     ).toBe('2');
   });
 
@@ -184,7 +188,9 @@ describe('Select.Basic', () => {
     toggleOpen(wrapper);
     expect(
       wrapper
-        .find('.rc-select-item-option-selected div.rc-select-item-option-content')
+        .find(
+          '.rc-select-item-option-selected div.rc-select-item-option-content',
+        )
         .map(node => node.text()),
     ).toEqual(['1', '2']);
   });
@@ -239,7 +245,9 @@ describe('Select.Basic', () => {
 
     wrapper.find('input').simulate('change', { target: { value: '1' } });
     expect(wrapper.find('List').props().data.length).toBe(1);
-    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe('One');
+    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe(
+      'One',
+    );
   });
 
   it('should filter options when filterOption is true', () => {
@@ -252,7 +260,9 @@ describe('Select.Basic', () => {
 
     wrapper.find('input').simulate('change', { target: { value: '2' } });
     expect(wrapper.find('List').props().data.length).toBe(1);
-    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe('Two');
+    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe(
+      'Two',
+    );
   });
 
   it('should not filter options when filterOption is false', () => {
@@ -300,7 +310,9 @@ describe('Select.Basic', () => {
     wrapper.find('input').simulate('change', { target: { value: 'Two2' } });
 
     expect(wrapper.find('List').props().data.length).toBe(1);
-    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe('Two2');
+    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe(
+      'Two2',
+    );
   });
 
   it('no search', () => {
@@ -517,7 +529,9 @@ describe('Select.Basic', () => {
     });
 
     it('set className', () => {
-      expect(wrapper.find('.rc-select').getDOMNode().className).toContain('-focus');
+      expect(wrapper.find('.rc-select').getDOMNode().className).toContain(
+        '-focus',
+      );
     });
   });
 
@@ -554,7 +568,9 @@ describe('Select.Basic', () => {
     });
 
     it('set className', () => {
-      expect(wrapper.find('.rc-select').getDOMNode().className).toContain('-focus');
+      expect(wrapper.find('.rc-select').getDOMNode().className).toContain(
+        '-focus',
+      );
     });
 
     it('click placeholder should trigger onFocus', () => {
@@ -583,7 +599,12 @@ describe('Select.Basic', () => {
       handleChange = jest.fn();
       handleBlur = jest.fn();
       wrapper = mount(
-        <Select onChange={handleChange} onBlur={handleBlur} showSearch optionLabelProp="children">
+        <Select
+          onChange={handleChange}
+          onBlur={handleBlur}
+          showSearch
+          optionLabelProp="children"
+        >
           <Option value={1} key={1}>
             1-text
           </Option>
@@ -609,7 +630,9 @@ describe('Select.Basic', () => {
     });
 
     it('set className', () => {
-      expect(wrapper.find('.rc-select').getDOMNode().className).not.toContain('-focus');
+      expect(wrapper.find('.rc-select').getDOMNode().className).not.toContain(
+        '-focus',
+      );
     });
 
     // Fix https://github.com/ant-design/ant-design/issues/6342
@@ -710,7 +733,10 @@ describe('Select.Basic', () => {
 
       public render() {
         return (
-          <Select open={this.state.open} onDropdownVisibleChange={this.onDropdownVisibleChange}>
+          <Select
+            open={this.state.open}
+            onDropdownVisibleChange={this.onDropdownVisibleChange}
+          >
             <Option value="1">1</Option>
           </Select>
         );
@@ -866,7 +892,9 @@ describe('Select.Basic', () => {
 
   it('warns on invalid children', () => {
     const Foo = value => <div>foo{value}</div>;
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => null);
     mount(
       <Select open>
         <Foo value="1" />
@@ -1063,7 +1091,9 @@ describe('Select.Basic', () => {
 
     wrapper.find('input').simulate('change', { target: { value: 'b' } });
     expect(wrapper.find('List').props().data).toHaveLength(1);
-    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe('ABC');
+    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe(
+      'ABC',
+    );
   });
 
   it('accepts prop id', () => {
@@ -1082,7 +1112,9 @@ describe('Select.Basic', () => {
       <Select
         defaultActiveFirstOption
         filterOption={(inputValue, option) =>
-          (option.children as string).toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
+          (option.children as string)
+            .toUpperCase()
+            .indexOf(inputValue.toUpperCase()) !== -1
         }
         onSelect={handleSelect}
         showSearch
@@ -1096,7 +1128,9 @@ describe('Select.Basic', () => {
     wrapper.find('input').simulate('change', { target: { value: 'b' } });
     expect(wrapper.find('input').props().value).toBe('b');
     expect(wrapper.find('List').props().data).toHaveLength(1);
-    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe('Burns Bay Road');
+    expect(wrapper.find('div.rc-select-item-option-content').text()).toBe(
+      'Burns Bay Road',
+    );
 
     wrapper.find('input').simulate('change', { target: { value: 'c' } });
     expect(wrapper.find('input').props().value).toBe('c');
@@ -1187,7 +1221,9 @@ describe('Select.Basic', () => {
 
   it('should warning using `onSearch` if not set `showSearch`', () => {
     resetWarned();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => null);
 
     mount(<Select onSearch={jest.fn()} />);
     expect(errorSpy).toHaveBeenCalledWith(
@@ -1240,12 +1276,15 @@ describe('Select.Basic', () => {
   describe('warning if use `props` to read data', () => {
     it('filterOption', () => {
       resetWarned();
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
 
       const wrapper = mount(
         <Select
           filterOption={(input, option) =>
-            option.props.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            option.props.children.toLowerCase().indexOf(input.toLowerCase()) >=
+            0
           }
           showSearch
         >
@@ -1256,7 +1295,9 @@ describe('Select.Basic', () => {
 
       wrapper.find('input').simulate('change', { target: { value: 'l' } });
       expect(wrapper.find('List').props().data).toHaveLength(1);
-      expect(wrapper.find('div.rc-select-item-option-content').text()).toBe('Light');
+      expect(wrapper.find('div.rc-select-item-option-content').text()).toBe(
+        'Light',
+      );
 
       expect(errorSpy).toHaveBeenCalledWith(
         'Warning: Return type is option instead of Option instance. Please read value directly instead of reading from `props`.',
@@ -1266,7 +1307,9 @@ describe('Select.Basic', () => {
 
     it('Select & Deselect', () => {
       resetWarned();
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
 
       const readPropsFunc = (_, opt) => {
         expect(opt.props).toBeTruthy();
@@ -1313,7 +1356,9 @@ describe('Select.Basic', () => {
 
     it('onChange', () => {
       resetWarned();
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
 
       const readPropsFunc = (_, opt) => {
         expect(opt.props).toBeTruthy();
@@ -1357,5 +1402,12 @@ describe('Select.Basic', () => {
 
   it('not crash when options is null', () => {
     mount(<Select options={null} />);
+  });
+
+  it('not open when `notFoundCount` is empty & no data', () => {
+    const wrapper = mount(
+      <Select options={null} open notFoundContent={null} />,
+    );
+    expect(wrapper.find('SelectTrigger').props().visible).toBeFalsy();
   });
 });


### PR DESCRIPTION
Hide popup when `notFoundContent` is `null` & `list` is empty.

ref: https://github.com/ant-design/ant-design/issues/19889