### PR TITLE
fix: Ensure Select's Dropdown Closes When Disabled

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -983,6 +983,7 @@ export default function generateSelector<
       [`${prefixCls}-show-search`]: mergedShowSearch,
     });
 
+    mergedOpen = disabled ? false : mergedOpen;
     return (
       <div
         className={mergedClassName}


### PR DESCRIPTION
### 🔗 Related issue links
[#20999](https://github.com/abdih/ant-design/pull/new/20999-ha-hide-select-dropdown-when-disabled)
[#21016](https://github.com/ant-design/ant-design/pull/21016)

### 🤔 This is a ...

- [x] Bug fix
### 💡 Background and solution

Want Select's drop-down to close once its 'disabled' property is updated to true.
### 📝 Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Validate 'open' attribute's value between ant-design's Select and that of rc-select to ensure its closed if 'disabled' is true |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
