### PR TITLE
improve performance, don't read offsetWidth when popup is not shown

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -895,11 +895,13 @@ export default function generateSelector<
     const [containerWidth, setContainerWidth] = React.useState(null);
 
     useLayoutEffect(() => {
-      const newWidth = Math.ceil(containerRef.current.offsetWidth);
-      if (containerWidth !== newWidth) {
-        setContainerWidth(newWidth);
+      if (triggerOpen) {
+        const newWidth = Math.ceil(containerRef.current.offsetWidth);
+        if (containerWidth !== newWidth) {
+          setContainerWidth(newWidth);
+        }
       }
-    });
+    }, [triggerOpen]);
 
     const popupNode = (
       <OptionList

--- a/tests/__snapshots__/Tags.test.tsx.snap
+++ b/tests/__snapshots__/Tags.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Select.Tags OptGroup renders correctly 1`] = `
     <div>
       <div
         class="rc-select-dropdown"
-        style="width: 0px; opacity: 0;"
+        style="opacity: 0; width: 0px;"
       >
         <div>
           <div


### PR DESCRIPTION
This fix a performance issue when components are update asynchronously

resolves: https://github.com/ant-design/ant-design/issues/21210 