### PR TITLE
Auto-adjust dropdown horizontally when dropdownMatchSelectWidth is false

### DIFF
--- a/examples/auto-adjust-dropdown.tsx
+++ b/examples/auto-adjust-dropdown.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable no-console */
+import React from 'react';
+import Select, { Option } from '../src';
+import '../assets/index.less';
+
+class Test extends React.Component {
+  state = {
+    value: '3',
+  };
+
+  onChange = e => {
+    let value;
+    if (e && e.target) {
+      ({ value } = e.target);
+    } else {
+      value = e;
+    }
+    this.setState({
+      value,
+    });
+  };
+
+  render() {
+    const { value } = this.state;
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          height: 'calc(100vh - 16px)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div>
+            <Select
+              onChange={this.onChange}
+              dropdownMatchSelectWidth={500}
+              value={value}
+            >
+              <Option value="1">
+                Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack
+              </Option>
+              <Option value="2">
+                Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy
+              </Option>
+              <Option value="3">Jill</Option>
+            </Select>
+          </div>
+          <div>
+            <Select
+              onChange={this.onChange}
+              dropdownMatchSelectWidth={500}
+              value={value}
+            >
+              <Option value="1">
+                Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack
+              </Option>
+              <Option value="2">
+                Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy
+              </Option>{' '}
+              <Option value="3">Jill</Option>
+            </Select>
+          </div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <div>
+            <Select
+              onChange={this.onChange}
+              dropdownMatchSelectWidth={500}
+              value={value}
+            >
+              <Option value="1">
+                Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack
+              </Option>
+              <Option value="2">
+                Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy
+              </Option>
+              <Option value="3">Jill</Option>
+            </Select>
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div>
+            <Select
+              onChange={this.onChange}
+              dropdownMatchSelectWidth={500}
+              value={value}
+            >
+              <Option value="1">
+                Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack
+              </Option>
+              <Option value="2">
+                Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy
+              </Option>
+              <Option value="3">Jill</Option>
+            </Select>
+          </div>
+          <div>
+            <Select
+              onChange={this.onChange}
+              dropdownMatchSelectWidth={500}
+              value={value}
+            >
+              <Option value="1">
+                Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack
+              </Option>
+              <Option value="2">
+                Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy
+              </Option>
+              <Option value="3">Jill</Option>
+            </Select>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Test;
+/* eslint-enable */

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -83,6 +83,11 @@ const SelectTrigger: React.RefForwardingComponent<
     popupNode = dropdownRender(popupElement);
   }
 
+  const builtInPlacements = React.useMemo(
+    () => getBuiltInPlacements(dropdownMatchSelectWidth),
+    [dropdownMatchSelectWidth],
+  );
+
   // ===================== Motion ======================
   const mergedTransitionName = animation
     ? `${dropdownPrefixCls}-${animation}`
@@ -101,7 +106,7 @@ const SelectTrigger: React.RefForwardingComponent<
       showAction={[]}
       hideAction={[]}
       popupPlacement="bottomLeft"
-      builtinPlacements={getBuiltInPlacements(dropdownMatchSelectWidth)}
+      builtinPlacements={builtInPlacements}
       prefixCls={dropdownPrefixCls}
       popupTransitionName={mergedTransitionName}
       popup={<div ref={popupRef}>{popupNode}</div>}

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -3,23 +3,28 @@ import Trigger from 'rc-trigger';
 import classNames from 'classnames';
 import { RenderDOMFunc } from './interface';
 
-const BUILT_IN_PLACEMENTS = {
-  bottomLeft: {
-    points: ['tl', 'bl'],
-    offset: [0, 4],
-    overflow: {
-      adjustX: 0,
-      adjustY: 1,
+const getBuiltInPlacements = (dropdownMatchSelectWidth: number | true) => {
+  // Enable horizontal overflow auto-adjustment when a custom dropdown width is provided
+  const adjustX = typeof dropdownMatchSelectWidth !== 'number' ? 0 : 1;
+
+  return {
+    bottomLeft: {
+      points: ['tl', 'bl'],
+      offset: [0, 4],
+      overflow: {
+        adjustX,
+        adjustY: 1,
+      },
     },
-  },
-  topLeft: {
-    points: ['bl', 'tl'],
-    offset: [0, -4],
-    overflow: {
-      adjustX: 0,
-      adjustY: 1,
+    topLeft: {
+      points: ['bl', 'tl'],
+      offset: [0, -4],
+      overflow: {
+        adjustX,
+        adjustY: 1,
+      },
     },
-  },
+  };
 };
 
 export interface RefTriggerProps {
@@ -96,7 +101,7 @@ const SelectTrigger: React.RefForwardingComponent<
       showAction={[]}
       hideAction={[]}
       popupPlacement="bottomLeft"
-      builtinPlacements={BUILT_IN_PLACEMENTS}
+      builtinPlacements={getBuiltInPlacements(dropdownMatchSelectWidth)}
       prefixCls={dropdownPrefixCls}
       popupTransitionName={mergedTransitionName}
       popup={<div ref={popupRef}>{popupNode}</div>}

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1182,6 +1182,32 @@ describe('Select.Basic', () => {
     ).toBe(233);
   });
 
+  it('dropdown should auto-adjust horizontally when dropdownMatchSelectWidth is false', () => {
+    const wrapper = mount(
+      <Select dropdownMatchSelectWidth={233}>
+        <Option value={0}>0</Option>
+        <Option value={1}>1</Option>
+      </Select>,
+    );
+    expect(
+      wrapper.find('Trigger').props().builtinPlacements.bottomLeft.overflow
+        .adjustX,
+    ).toBe(1);
+  });
+
+  it('dropdown should not auto-adjust horizontally when dropdownMatchSelectWidth is true', () => {
+    const wrapper = mount(
+      <Select>
+        <Option value={0}>0</Option>
+        <Option value={1}>1</Option>
+      </Select>,
+    );
+    expect(
+      wrapper.find('Trigger').props().builtinPlacements.bottomLeft.overflow
+        .adjustX,
+    ).toBe(0);
+  });
+
   it('if loading, arrow should show loading icon', () => {
     const wrapper = mount(
       <Select style={{ width: 1000 }} loading>


### PR DESCRIPTION
Originally, when dropdownMatchSelectWidth is not provided and the width of the dropdown is larger than the width of the Select input, the dropdown will overflow instead of adjusting position automatically. This change checks dropdownMatchSelectWidth changes the dropdown placement overflow.adjustX accordingly

## Before:
![image](https://user-images.githubusercontent.com/3173273/76263167-3249c580-622c-11ea-87be-b073e6c7d34f.png)
## After:
![image](https://user-images.githubusercontent.com/3173273/76263199-4392d200-622c-11ea-9840-13b9fd941044.png)
