### PR TITLE
fix: added type=search to input component to prevent autocomplete to be shown in Chromium

### DIFF
--- a/src/Selector/Input.tsx
+++ b/src/Selector/Input.tsx
@@ -73,6 +73,7 @@ const Input: React.RefForwardingComponent<InputRef, InputProps> = (
     disabled,
     tabIndex,
     autoComplete: autoComplete || 'off',
+    type: 'search',
     autoFocus,
     className: `${prefixCls}-selection-search-input`,
     style: { ...style, opacity: editable ? null : 0 },

--- a/tests/Input.test.tsx
+++ b/tests/Input.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Input from '../src/Selector/Input';
+
+describe('Selector.Input', () => {
+  it('renders correctly', () => {
+    const noop = () => null;
+    const wrapper = mount(
+      <Input
+        prefixCls=""
+        id="abc"
+        inputElement={<input />}
+        disabled={false}
+        autoFocus={false}
+        editable={false}
+        accessibilityIndex={1}
+        value="abc"
+        open={false}
+        tabIndex={-5}
+        onKeyDown={noop}
+        onMouseDown={noop}
+        onChange={noop}
+      />,
+    );
+
+    expect(wrapper.find('input').prop('type')).toBe('search');
+  });
+});

--- a/tests/__snapshots__/Combobox.test.tsx.snap
+++ b/tests/__snapshots__/Combobox.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Select.Combobox renders correctly 1`] = `
         class="rc-select-selection-search-input"
         id="rc_select_TEST_OR_SSR"
         role="combobox"
+        type="search"
         value=""
       />
     </span>

--- a/tests/__snapshots__/Multiple.test.tsx.snap
+++ b/tests/__snapshots__/Multiple.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Select.Multiple render not display maxTagPlaceholder if maxTagCount not
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -116,6 +117,7 @@ exports[`Select.Multiple render truncates tags by maxTagCount and show maxTagPla
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -206,6 +208,7 @@ exports[`Select.Multiple render truncates tags by maxTagCount and show maxTagPla
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -285,6 +288,7 @@ exports[`Select.Multiple render truncates values by maxTagTextLength 1`] = `
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        type="search"
         unselectable="on"
         value=""
       />

--- a/tests/__snapshots__/Select.test.tsx.snap
+++ b/tests/__snapshots__/Select.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Select.Basic does not filter when filterOption value is false 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -149,6 +150,7 @@ exports[`Select.Basic filterOption could be true as described in default value 1
         class="rc-select-selection-search-input"
         id="rc_select_TEST_OR_SSR"
         role="combobox"
+        type="search"
         value="3"
       />
     </span>
@@ -203,6 +205,7 @@ exports[`Select.Basic no search 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -252,6 +255,7 @@ exports[`Select.Basic render renders aria-attributes correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -309,6 +313,7 @@ exports[`Select.Basic render renders correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -368,6 +373,7 @@ exports[`Select.Basic render renders data-attributes correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -427,6 +433,7 @@ exports[`Select.Basic render renders disabled select correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -471,6 +478,7 @@ exports[`Select.Basic render renders dropdown correctly 1`] = `
         autocomplete="off"
         class="antd-selection-search-input"
         role="combobox"
+        type="search"
         value=""
       />
     </span>
@@ -654,6 +662,7 @@ exports[`Select.Basic render renders role prop correctly 1`] = `
         readonly=""
         role="button"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -712,6 +721,7 @@ exports[`Select.Basic should contain falsy children 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        type="search"
         unselectable="on"
         value=""
       />
@@ -849,6 +859,7 @@ exports[`Select.Basic should render custom dropdown correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        type="search"
         unselectable="on"
         value=""
       />

--- a/tests/__snapshots__/Tags.test.tsx.snap
+++ b/tests/__snapshots__/Tags.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`Select.Tags OptGroup renders correctly 1`] = `
           class="rc-select-selection-search-input"
           id="rc_select_TEST_OR_SSR"
           role="combobox"
+          type="search"
           value=""
         />
         <span
@@ -224,6 +225,7 @@ exports[`Select.Tags render not display maxTagPlaceholder if maxTagCount not rea
         class="rc-select-selection-search-input"
         id="rc_select_TEST_OR_SSR"
         role="combobox"
+        type="search"
         value=""
       />
       <span
@@ -314,6 +316,7 @@ exports[`Select.Tags render truncates tags by maxTagCount and show maxTagPlaceho
         class="rc-select-selection-search-input"
         id="rc_select_TEST_OR_SSR"
         role="combobox"
+        type="search"
         value=""
       />
       <span
@@ -401,6 +404,7 @@ exports[`Select.Tags render truncates tags by maxTagCount and show maxTagPlaceho
         class="rc-select-selection-search-input"
         id="rc_select_TEST_OR_SSR"
         role="combobox"
+        type="search"
         value=""
       />
       <span
@@ -477,6 +481,7 @@ exports[`Select.Tags render truncates values by maxTagTextLength 1`] = `
         class="rc-select-selection-search-input"
         id="rc_select_TEST_OR_SSR"
         role="combobox"
+        type="search"
         value=""
       />
       <span


### PR DESCRIPTION
See here for more information about that issue.
- https://github.com/ant-design/ant-design/issues/18808
- https://stackoverflow.com/a/35639702/6512681
- https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands

In a nutshell for input fields which don't have the `type="search"` attribute the autocomplete popup is shown in Chromium based browsers. `autocomplete="off"` is not working anymore in Chromium. We have to use either `autocomplete="new-password"` (or any not existing autocomplete attribute) or `type="search"` which seems to be the better way.

It seems like the issue is much bigger than that:
https://bugs.chromium.org/p/chromium/issues/detail?id=370363#c7