### PR TITLE
fix(#24034): add unselectable for ie11;

### DIFF
--- a/src/Selector/Input.tsx
+++ b/src/Selector/Input.tsx
@@ -72,6 +72,7 @@ const Input: React.RefForwardingComponent<InputRef, InputProps> = (
     'aria-activedescendant': `${id}_list_${accessibilityIndex}`,
     value: editable ? value : '',
     readOnly: !editable,
+    unselectable: !editable ? 'on' : null,
     onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
       onKeyDown(event);
       if (onOriginKeyDown) {


### PR DESCRIPTION
add `readonly` compatibility for IE11