### PR TITLE
fix(#24034): add `readonly` compatibility for IE11

### DIFF
--- a/src/Selector/Input.tsx
+++ b/src/Selector/Input.tsx
@@ -72,6 +72,7 @@ const Input: React.RefForwardingComponent<InputRef, InputProps> = (
     'aria-activedescendant': `${id}_list_${accessibilityIndex}`,
     value: editable ? value : '',
     readOnly: !editable,
+    unselectable: !editable ? 'on' : null,
     onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
       onKeyDown(event);
       if (onOriginKeyDown) {

--- a/tests/__snapshots__/Multiple.test.tsx.snap
+++ b/tests/__snapshots__/Multiple.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Select.Multiple render not display maxTagPlaceholder if maxTagCount not
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        unselectable="on"
         value=""
       />
       <span
@@ -115,6 +116,7 @@ exports[`Select.Multiple render truncates tags by maxTagCount and show maxTagPla
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        unselectable="on"
         value=""
       />
       <span
@@ -204,6 +206,7 @@ exports[`Select.Multiple render truncates tags by maxTagCount and show maxTagPla
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        unselectable="on"
         value=""
       />
       <span
@@ -282,6 +285,7 @@ exports[`Select.Multiple render truncates values by maxTagTextLength 1`] = `
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        unselectable="on"
         value=""
       />
       <span

--- a/tests/__snapshots__/Select.test.tsx.snap
+++ b/tests/__snapshots__/Select.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Select.Basic does not filter when filterOption value is false 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -195,6 +196,7 @@ exports[`Select.Basic no search 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -240,6 +242,7 @@ exports[`Select.Basic render renders aria-attributes correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -295,6 +298,7 @@ exports[`Select.Basic render renders correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -352,6 +356,7 @@ exports[`Select.Basic render renders data-attributes correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -409,6 +414,7 @@ exports[`Select.Basic render renders disabled select correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -627,6 +633,7 @@ exports[`Select.Basic render renders role prop correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -683,6 +690,7 @@ exports[`Select.Basic should contain falsy children 1`] = `
         readonly=""
         role="combobox"
         style="opacity:0"
+        unselectable="on"
         value=""
       />
     </span>
@@ -811,6 +819,7 @@ exports[`Select.Basic should render custom dropdown correctly 1`] = `
         readonly=""
         role="combobox"
         style="opacity: 0;"
+        unselectable="on"
         value=""
       />
     </span>


### PR DESCRIPTION
add `readonly` compatibility for IE11 [#24034](https://github.com/ant-design/ant-design/issues/24034)