### PR TITLE
build: migrate to dumi & father-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tsconfig.test.json
 .prettierignore
 .storybook
 storybook/index.js
+.umi

--- a/.umirc.ts
+++ b/.umirc.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'dumi';
+
+export default defineConfig({
+  logo: 'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',
+  outputPath: '.doc',
+  exportStatic: {},
+});

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ export default () => (
 | filterOption | whether filter options by input value. default filter by option's optionFilterProp prop's value | bool | true/Function(inputValue:string, option:Option) |
 | optionFilterProp | which prop value of option will be used for filter if filterOption is true | String | 'value' |
 | optionLabelProp | render option value or option children as content of select | String: 'value'/'children' | 'value' |
-| defaultValue | initial selected option(s) | String/Array<String> | - |
-| value | current selected option(s) | String/Array<String>/{key:String, label:React.Node}/Array<{key, label}> | - |
+| defaultValue | initial selected option(s) | String/Array&lt;String&gt; | - |
+| value | current selected option(s) | String/Array&lt;String&gt;/{key:String, label:React.Node}/Array&lt;{key, label}&gt; | - |
 | labelInValue | whether to embed label in value, see above value type. Not support `combobox` mode | Bool | false |
 | backfill | whether backfill select option to search input (Only works in single and combobox mode) | Bool | false |
-| onChange | called when select an option or input value change(combobox) | function(value, option:Option/Array<Option>) | - |
+| onChange | called when select an option or input value change(combobox) | function(value, option:Option/Array&lt;Option&gt;) | - |
 | onSearch | called when input changed | function | - |
 | onBlur | called when blur | function | - |
 | onFocus | called when focus | function | - |

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   },
   "license": "MIT",
   "scripts": {
-    "start": "cross-env NODE_ENV=development father doc dev --storybook",
-    "build": "father doc build --storybook",
-    "compile": "father build",
+    "start": "dumi dev",
+    "build": "dumi build",
+    "compile": "father-build",
     "prepublishOnly": "npm run compile && np --no-cleanup --yolo --no-publish",
     "lint": "eslint src/ examples/ --ext .tsx,.ts,.jsx,.js",
-    "test": "father test",
+    "test": "umi-test",
     "now-build": "npm run build"
   },
   "peerDependencies": {
@@ -56,14 +56,17 @@
     "@types/react": "^16.8.19",
     "@types/react-dom": "^16.8.4",
     "@types/warning": "^3.0.0",
+    "@umijs/test": "^3.1.4",
     "cross-env": "^7.0.0",
+    "dumi": "^1.0.24",
     "enzyme": "^3.3.0",
     "enzyme-to-json": "^3.4.0",
     "eslint": "^6.8.0",
-    "father": "^2.13.2",
+    "father-build": "^1.18.0",
     "jsonp": "^0.2.1",
     "np": "^6.0.0",
     "rc-dialog": "^7.5.5",
-    "typescript": "^3.5.2"
+    "typescript": "^3.5.2",
+    "umi-test": "^1.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/react": "^16.8.19",
     "@types/react-dom": "^16.8.4",
     "@types/warning": "^3.0.0",
-    "@umijs/test": "^3.1.4",
     "cross-env": "^7.0.0",
     "dumi": "^1.0.24",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
## Changes
- Use `dumi` instead of `storybook` as the doc tool
- Use `father-build` instead of `father` as the build tool to reduce install size