### PR TITLE
Added onBeforeBlur property for cancelation onBlur event

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ export default () => (
 | backfill | whether backfill select option to search input (Only works in single and combobox mode) | Bool | false |
 | onChange | called when select an option or input value change(combobox) | function(value, option:Option/Array<Option>) | - |
 | onSearch | called when input changed | function | - |
+| onBeforeBlur | called when blur, if returned true onBlur will be fired, else onBlur won't fired | function(event) => boolean | - |
 | onBlur | called when blur | function | - |
 | onFocus | called when focus | function | - |
 | onPopupScroll | called when menu is scrolled | function | - |

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -139,6 +139,7 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   onInputKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   onClick?: React.MouseEventHandler;
   onChange?: (value: ValueType, option: OptionsType[number] | OptionsType) => void;
+  onBeforeBlur?: (event: React.FocusEvent<HTMLElement>) => boolean;
   onBlur?: React.FocusEventHandler<HTMLElement>;
   onFocus?: React.FocusEventHandler<HTMLElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
@@ -294,6 +295,7 @@ export default function generateSelector<
       onPopupScroll,
       onDropdownVisibleChange,
       onFocus,
+      onBeforeBlur,
       onBlur,
       onKeyUp,
       onKeyDown,
@@ -759,6 +761,8 @@ export default function generateSelector<
     };
 
     const onContainerBlur: React.FocusEventHandler<HTMLElement> = (...args) => {
+      if (onBeforeBlur && !onBeforeBlur(args[0])) return;
+
       setMockFocused(false, () => {
         focusRef.current = false;
         onToggleOpen(false);

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -681,6 +681,52 @@ describe('Select.Basic', () => {
       expect(onFocus).not.toHaveBeenCalled();
       expect(onBlur).not.toHaveBeenCalled();
     });
+
+    it('should not trigger onBlur when onBeforeBlur returned false', () => {
+      const onFocus = jest.fn();
+      const onBlur = jest.fn();
+      wrapper = mount(
+        <Select
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onBeforeBlur={() => {
+            return false;
+          }}
+        >
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>,
+      );
+      jest.useFakeTimers();
+      wrapper.find('input').simulate('focus');
+      wrapper.find('input').simulate('blur');
+      jest.runAllTimers();
+      expect(onFocus).toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
+    });
+
+    it('should trigger onBlur when onBeforeBlur returned true', () => {
+      const onFocus = jest.fn();
+      const onBlur = jest.fn();
+      wrapper = mount(
+        <Select
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onBeforeBlur={() => {
+            return true;
+          }}
+        >
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>,
+      );
+      jest.useFakeTimers();
+      wrapper.find('input').simulate('focus');
+      wrapper.find('input').simulate('blur');
+      jest.runAllTimers();
+      expect(onFocus).toHaveBeenCalled();
+      expect(onBlur).toHaveBeenCalled();
+    });
   });
 
   [KeyCode.ENTER, KeyCode.DOWN].forEach(keyCode => {


### PR DESCRIPTION
When using `select` component in our case we need cancel `onBlur` event. I think it's useful for all. Added new property onBeforeBlur, that called in onBlur. If `onBeforeBlur` === true, onBlur will work like before, else onBlur will be cancel. 

Also i added two tests for this property.