### PR TITLE
fix(22907): cannot open Select when mode="tags" or mode="multiple" has searc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-select",
-  "version": "10.3.4",
+  "version": "10.3.5",
   "description": "React Select",
   "engines": {
     "node": ">=8.x"

--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -202,9 +202,12 @@ const SelectSelector: React.FC<SelectorProps> = ({
         </span>
       </span>
 
-      {!values.length && !inputValue && (
-        <span className={`${prefixCls}-selection-placeholder`}>{placeholder}</span>
-      )}
+      <span
+        className={`${prefixCls}-selection-placeholder`}
+        style={{ display: !values.length && !inputValue ? 'block' : 'none' }}
+      >
+        {placeholder}
+      </span>
     </>
   );
 };


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/22907

原因：
1. 在mode=tags或multiple存在searchValue情况下，点击placeholder会先正常展示出Options，并移除了placeholder节点
2. 会触发useSelectTriggerControl hook，此时的target节点是已删除掉的placeholder节点，导致if判断为true，触发triggerOpen(false)隐藏掉Options

<img width="710" alt="屏幕快照 2020-05-23 下午1 32 05" src="https://user-images.githubusercontent.com/9320755/82722490-d73b5100-9cf9-11ea-9613-fe1c66ed682e.png">