### PR TITLE
feat: Add flag for disabling remove on backspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ export default () => (
 | allowClear | whether allowClear | bool | false |
 | tags | when tagging is enabled the user can select from pre-existing options or create a new tag by picking the first choice, which is what the user has typed into the search box so far. | bool | false |
 | tagRender | render custom tags. | (props: CustomTagProps) => ReactNode | - |
+| removeOnBackspace | whether or not pressing backspace will deselect the option | boolean | true |
 | maxTagTextLength | max tag text length to show | number | - |
 | maxTagCount | max tag count to show | number | - |
 | maxTagPlaceholder | placeholder for omitted values | ReactNode/function(omittedValues) | - |

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -129,6 +129,7 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   tagRender?: (props: CustomTagProps) => React.ReactElement;
   showAction?: ('focus' | 'click')[];
   tabIndex?: number;
+  removeOnBackspace?: boolean;
 
   // Events
   onKeyUp?: React.KeyboardEventHandler<HTMLDivElement>;
@@ -272,6 +273,7 @@ export default function generateSelector<
       backfill,
       getInputElement,
       getPopupContainer,
+      removeOnBackspace = true,
 
       // Dropdown
       listHeight = 200,
@@ -711,6 +713,7 @@ export default function generateSelector<
 
       // Remove value by `backspace`
       if (
+        removeOnBackspace &&
         which === KeyCode.BACKSPACE &&
         !clearLock &&
         isMultiple &&

--- a/tests/shared/removeSelectedTest.tsx
+++ b/tests/shared/removeSelectedTest.tsx
@@ -88,6 +88,19 @@ export default function removeSelectedTest(mode: any) {
       expect(onChange).toHaveBeenCalledWith(['1'], [expect.objectContaining({ value: '1' })]);
     });
 
+    it('does not remove by backspace key if removeOnBackspace is disabled', () => {
+      const onChange = jest.fn();
+      const wrapper = mount(
+        <Select defaultValue={['1', '2']} mode={mode} onChange={onChange} removeOnBackspace={false}>
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>,
+      );
+
+      wrapper.find('input').simulate('keyDown', { which: KeyCode.BACKSPACE });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('remove by menu deselect', () => {
       const onChange = jest.fn();
       const wrapper = mount(


### PR DESCRIPTION
This addresses https://github.com/ant-design/ant-design/issues/15392: Avoid to remove tag when pressing backspace on select.

This resolves the issue by adding the suggested `removeOnBackspace: boolean` prop to enable or disable the backspace feature (enabled by default).