### PR TITLE
fix: input onChange fires with duplicated value when wrapped in select and using paste

### DIFF
--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -189,9 +189,8 @@ const Selector: React.RefForwardingComponent<RefSelectorProps, SelectorProps> = 
     pasteClearRef.current = true;
     setTimeout(() => {
       pasteClearRef.current = false;
+      triggerOnSearch(value);
     });
-
-    triggerOnSearch(value);
   };
 
   // ====================== Focus ======================

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -140,7 +140,8 @@ describe('Select.Tags', () => {
     expectOpen(wrapper, false);
   });
 
-  it('paste content to split', () => {
+  it('paste content to split after 100ms', done => {
+    jest.useFakeTimers();
     const onChange = jest.fn();
     const wrapper = mount(
       <Select mode="tags" tokenSeparators={[' ', '\n']} onChange={onChange}>
@@ -160,8 +161,16 @@ describe('Select.Tags', () => {
       target: { value: '         light         bamboo         ' },
     });
 
-    expect(onChange).toHaveBeenCalledWith(['light', 'bamboo'], expect.anything());
-    expect(onChange).toHaveBeenCalledTimes(1);
+    setTimeout(() => {
+      try {
+        expect(onChange).toHaveBeenCalledWith(['light', 'bamboo'], expect.anything());
+        expect(onChange).toHaveBeenCalledTimes(1);
+        done();
+      } catch (err) {
+        done.fail(err);
+      }
+    }, 100);
+    jest.runTimersToTime(100);
   });
 
   it('renders unlisted item in value', () => {


### PR DESCRIPTION
To fix this issue: https://github.com/ant-design/ant-design/issues/25228
Input update firstly when value was pasted, but `triggerOnSearch` will call `setMergedValue` before Input didupdate, so `triggerOnSearch` should be assign in next macrotask.