### PR TITLE
feat: Update Tags Mode to display options matched with optionFilterProp

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -429,7 +429,10 @@ export default function generateSelector<
         optionFilterProp,
         filterOption: mode === 'combobox' && filterOption === undefined ? () => true : filterOption,
       });
-      if (mode === 'tags' && filteredOptions.every(opt => opt.value !== mergedSearchValue)) {
+      if (
+        mode === 'tags' &&
+        filteredOptions.every(opt => opt[optionFilterProp] !== mergedSearchValue)
+      ) {
         filteredOptions.unshift({
           value: mergedSearchValue,
           label: mergedSearchValue,

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -224,6 +224,21 @@ describe('Select.Tags', () => {
     ]);
   });
 
+  it('renders options matched with optionFilterProp', () => {
+    const wrapper = mount(
+      <Select open value="22" mode="tags" searchValue="option-1" optionFilterProp="children">
+        <Option value="1">option-1</Option>
+        <Option value="2">option-2</Option>
+      </Select>,
+    );
+
+    expect(wrapper.find('List').props().data).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ value: '1' }),
+      }),
+    ]);
+  });
+
   it('use filterOption', () => {
     const filterOption = (inputValue, option) =>
       option.value.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1;


### PR DESCRIPTION
## Descriptions
- When using `mode=tags`, it search values based on `optionFilterProp` value. However, Even If the option which has the same `optionFilterProp` value, `mode=tags` unshift new option to `displayOptions`.

## Suggestion
- For now, it checks values between `option.value` and `mergedSearchValue` to decide whether it unshift new option or not
- I think that the condition should be changed to use `optionFilterProp`. 
