### PR TITLE
fix: Keyboard not showing up on iOS when focus

### DIFF
--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -197,12 +197,8 @@ const Selector: React.RefForwardingComponent<RefSelectorProps, SelectorProps> = 
     pastedTextRef.current = value;
   };
 
-  const onMouseDown: React.MouseEventHandler<HTMLElement> = event => {
-    const inputMouseDown = getInputMouseDown();
-    if (event.target !== inputRef.current) {
-      if (!inputMouseDown) {
-        event.preventDefault();
-      }
+  const onClick = ({ target }) => {
+    if (target !== inputRef.current) {
       // Should focus input if click the selector
       const isIE = (document.body.style as any).msTouchAction !== undefined;
       if (isIE) {
@@ -212,6 +208,13 @@ const Selector: React.RefForwardingComponent<RefSelectorProps, SelectorProps> = 
       } else {
         inputRef.current.focus();
       }
+    }
+  };
+
+  const onMouseDown: React.MouseEventHandler<HTMLElement> = event => {
+    const inputMouseDown = getInputMouseDown();
+    if (event.target !== inputRef.current && !inputMouseDown) {
+      event.preventDefault();
     }
 
     if ((mode !== 'combobox' && (!showSearch || !inputMouseDown)) || !open) {
@@ -240,7 +243,12 @@ const Selector: React.RefForwardingComponent<RefSelectorProps, SelectorProps> = 
   );
 
   return (
-    <div ref={domRef} className={`${prefixCls}-selector`} onMouseDown={onMouseDown}>
+    <div
+      ref={domRef}
+      className={`${prefixCls}-selector`}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+    >
       {selectNode}
     </div>
   );


### PR DESCRIPTION
close [#26648](https://github.com/ant-design/ant-design/issues/26648)

@afc163 

发现是这次提交导致的问题：https://github.com/react-component/select/commit/ed63549d8cef1e728057b7a55ecabaf61fff7b96

我看你把 focus 从 `onClick` 挪到了 `onMouseDown` 中，这导致在 IOS 上无法正常聚焦调起键盘，我又放回在 `onClick` 中了，你看看有什么问题？