### PR TITLE
fix: circular reference in the option prop of select

### DIFF
--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -79,7 +79,7 @@ function injectPropsWithOption<T>(option: T): T {
           false,
           'Return type is option instead of Option instance. Please read value directly instead of reading from `props`.',
         );
-        return newOption;
+        return option;
       },
     });
   }


### PR DESCRIPTION
If return `newOption`, `props` in `newOption` will cause circular reference. `props` of `newOption` will has `props` of `newOption`.
```ts
option.props.props.props === option.props   // this is true
```