### PR TITLE
feat: mount scrollTo on ref

### DIFF
--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -11,6 +11,7 @@
 import * as React from 'react';
 import { useRef } from 'react';
 import KeyCode from 'rc-util/lib/KeyCode';
+import { ScrollTo } from 'rc-virtual-list/lib/List';
 import MultipleSelector from './MultipleSelector';
 import SingleSelector from './SingleSelector';
 import { LabelValueType, RawValueType, CustomTagProps } from '../interface/generator';
@@ -45,6 +46,7 @@ export interface InnerSelectorProps {
 export interface RefSelectorProps {
   focus: () => void;
   blur: () => void;
+  scrollTo?: ScrollTo,
 }
 
 export interface SelectorProps {

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -12,6 +12,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import classNames from 'classnames';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
+import { ScrollTo } from 'rc-virtual-list/lib/List';
 import Selector, { RefSelectorProps } from './Selector';
 import SelectTrigger, { RefTriggerProps } from './SelectTrigger';
 import { RenderNode, Mode, RenderDOMFunc, OnActiveValue } from './interface';
@@ -57,6 +58,7 @@ const DEFAULT_OMIT_PROPS = [
 export interface RefSelectProps {
   focus: () => void;
   blur: () => void;
+  scrollTo?: ScrollTo,
 }
 
 export interface SelectProps<OptionsType extends object[], ValueType> extends React.AriaAttributes {
@@ -365,6 +367,7 @@ export default function generateSelector<
     React.useImperativeHandle(ref, () => ({
       focus: selectorRef.current.focus,
       blur: selectorRef.current.blur,
+      scrollTo: listRef.current?.scrollTo,
     }));
 
     // ============================= Value ==============================


### PR DESCRIPTION
将 `scrollTo` 能力暴露出来

相关 issue：
https://github.com/ant-design/ant-design/issues/24240

相关 PR：
https://github.com/react-component/tree-select/pull/298