### PR TITLE
fix:tabindex prop will be set only on input element

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -52,6 +52,7 @@ const DEFAULT_OMIT_PROPS = [
   'maxTagPlaceholder',
   'choiceTransitionName',
   'onInputKeyDown',
+  'tabIndex',
 ];
 
 export interface RefSelectProps {


### PR DESCRIPTION
about [#27964](https://github.com/ant-design/ant-design/issues/27964)