### PR TITLE
feat: `maxTagCount="responsive"`

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -117,8 +117,20 @@
       }
     }
 
+    .@{select-prefix}-selection-overflow {
+      display: flex;
+      flex-wrap: wrap;
+      width: 100%;
+
+      &-item {
+        flex: none;
+        max-width: 100%;
+      }
+    }
+
     .@{select-prefix}-selection-search {
       position: relative;
+      max-width: 100%;
 
       &-input,
       &-mirror {

--- a/examples/tags.tsx
+++ b/examples/tags.tsx
@@ -14,10 +14,20 @@ for (let i = 10; i < 36; i += 1) {
 
 const Test: React.FC = () => {
   const [disabled, setDisabled] = React.useState(false);
-  const [value, setValue] = React.useState<string[]>(['name2', 'name3']);
-  const [maxTagCount, setMaxTagCount] = React.useState<number>(null);
+  const [value, setValue] = React.useState<string[]>([
+    'name1',
+    'name2',
+    'name3',
+    'name4',
+    'name5',
+    'a10',
+    'b11',
+    'c12',
+    'd13',
+  ]);
+  const [maxTagCount, setMaxTagCount] = React.useState<number | 'responsive'>('responsive');
 
-  const toggleMaxTagCount = (count: number) => {
+  const toggleMaxTagCount = (count: number | 'responsive') => {
     setMaxTagCount(count);
   };
 
@@ -29,7 +39,7 @@ const Test: React.FC = () => {
         <Select
           placeholder="placeholder"
           mode="tags"
-          style={{ width: 500 }}
+          style={{ width: 400 }}
           disabled={disabled}
           maxTagCount={maxTagCount}
           maxTagTextLength={10}
@@ -68,6 +78,9 @@ const Test: React.FC = () => {
         </button>
         <button type="button" onClick={() => toggleMaxTagCount(null)}>
           toggle maxTagCount (null)
+        </button>
+        <button type="button" onClick={() => toggleMaxTagCount('responsive')}>
+          toggle maxTagCount (responsive)
         </button>
       </p>
       <h2>tags select with open = false</h2>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.10.1",
     "classnames": "2.x",
     "rc-motion": "^2.0.1",
-    "rc-overflow": "^0.0.0-alpha.4",
+    "rc-overflow": "^0.0.0-alpha.5",
     "rc-trigger": "^5.0.4",
     "rc-util": "^5.0.1",
     "rc-virtual-list": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -46,17 +46,16 @@
     "@babel/runtime": "^7.10.1",
     "classnames": "2.x",
     "rc-motion": "^2.0.1",
+    "rc-overflow": "^0.0.0-alpha.4",
     "rc-trigger": "^5.0.4",
     "rc-util": "^5.0.1",
-    "rc-virtual-list": "^3.2.0",
-    "warning": "^4.0.3"
+    "rc-virtual-list": "^3.2.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^26.0.0",
     "@types/react": "^16.8.19",
     "@types/react-dom": "^16.8.4",
-    "@types/warning": "^3.0.0",
     "cross-env": "^7.0.0",
     "enzyme": "^3.3.0",
     "enzyme-to-json": "^3.4.0",

--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -69,7 +69,7 @@ export interface SelectorProps {
   removeIcon?: RenderNode;
 
   // Tags
-  maxTagCount?: number;
+  maxTagCount?: number | 'responsive';
   maxTagTextLength?: number;
   maxTagPlaceholder?: React.ReactNode | ((omittedValues: LabelValueType[]) => React.ReactNode);
   tagRender?: (props: CustomTagProps) => React.ReactElement;

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -192,7 +192,7 @@ export interface GenerateConfig<OptionsType extends object[]> {
   getLabeledValue: GetLabeledValue<FlattenOptionsType<OptionsType>>;
   filterOptions: FilterOptions<OptionsType>;
   findValueOption: // Need still support legacy ts api
-  | ((values: RawValueType[], options: FlattenOptionsType<OptionsType>) => OptionsType)
+    | ((values: RawValueType[], options: FlattenOptionsType<OptionsType>) => OptionsType)
     // New API add prevValueOptions support
     | ((
         values: RawValueType[],
@@ -714,9 +714,7 @@ export default function generateSelector<
     // If menu is open, OptionList will take charge
     // If mode isn't tags, press enter is not meaningful when you can't see any option
     const onSearchSubmit = (searchText: string) => {
-      const newRawValues = Array.from(
-        new Set<RawValueType>([...mergedRawValue, searchText]),
-      );
+      const newRawValues = Array.from(new Set<RawValueType>([...mergedRawValue, searchText]));
       triggerChange(newRawValues);
       newRawValues.forEach(newRawValue => {
         triggerSelect(newRawValue, true, 'input');

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -129,7 +129,7 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   getInputElement?: () => JSX.Element;
   optionLabelProp?: string;
   maxTagTextLength?: number;
-  maxTagCount?: number;
+  maxTagCount?: number | 'responsive';
   maxTagPlaceholder?: React.ReactNode | ((omittedValues: LabelValueType[]) => React.ReactNode);
   tokenSeparators?: string[];
   tagRender?: (props: CustomTagProps) => React.ReactElement;
@@ -192,7 +192,7 @@ export interface GenerateConfig<OptionsType extends object[]> {
   getLabeledValue: GetLabeledValue<FlattenOptionsType<OptionsType>>;
   filterOptions: FilterOptions<OptionsType>;
   findValueOption: // Need still support legacy ts api
-    | ((values: RawValueType[], options: FlattenOptionsType<OptionsType>) => OptionsType)
+  | ((values: RawValueType[], options: FlattenOptionsType<OptionsType>) => OptionsType)
     // New API add prevValueOptions support
     | ((
         values: RawValueType[],
@@ -714,7 +714,9 @@ export default function generateSelector<
     // If menu is open, OptionList will take charge
     // If mode isn't tags, press enter is not meaningful when you can't see any option
     const onSearchSubmit = (searchText: string) => {
-      const newRawValues = Array.from(new Set<RawValueType>([...mergedRawValue, searchText]));
+      const newRawValues = Array.from(
+        new Set<RawValueType>([...mergedRawValue, searchText]),
+      );
       triggerChange(newRawValues);
       newRawValues.forEach(newRawValue => {
         triggerSelect(newRawValue, true, 'input');

--- a/src/interface/generator.ts
+++ b/src/interface/generator.ts
@@ -14,24 +14,18 @@ export interface LabelValueType {
   value?: RawValueType;
   label?: React.ReactNode;
 }
-export type DefaultValueType =
-  | RawValueType
-  | RawValueType[]
-  | LabelValueType
-  | LabelValueType[];
+export type DefaultValueType = RawValueType | RawValueType[] | LabelValueType | LabelValueType[];
 
 export interface DisplayLabelValueType extends LabelValueType {
   disabled?: boolean;
 }
 
-export type SingleType<MixType> = MixType extends (infer Single)[]
-  ? Single
-  : MixType;
+export type SingleType<MixType> = MixType extends (infer Single)[] ? Single : MixType;
 
 export type OnClear = () => void;
 
 export type CustomTagProps = {
-  label: DefaultValueType;
+  label: React.ReactNode;
   value: DefaultValueType;
   disabled: boolean;
   onClose: (event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
@@ -59,19 +53,12 @@ export type FilterOptions<OptionsType extends object[]> = (
   },
 ) => OptionsType;
 
-export type FilterFunc<OptionType> = (
-  inputValue: string,
-  option?: OptionType,
-) => boolean;
+export type FilterFunc<OptionType> = (inputValue: string, option?: OptionType) => boolean;
 
 export declare function RefSelectFunc<OptionsType extends object[], ValueType>(
-  Component: React.RefForwardingComponent<
-    RefSelectProps,
-    SelectProps<OptionsType, ValueType>
-  >,
+  Component: React.RefForwardingComponent<RefSelectProps, SelectProps<OptionsType, ValueType>>,
 ): React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<SelectProps<OptionsType, ValueType>> &
-    React.RefAttributes<RefSelectProps>
+  React.PropsWithoutRef<SelectProps<OptionsType, ValueType>> & React.RefAttributes<RefSelectProps>
 >;
 
 export type FlattenOptionsType<OptionsType extends object[] = object[]> = {

--- a/tests/__snapshots__/Multiple.test.tsx.snap
+++ b/tests/__snapshots__/Multiple.test.tsx.snap
@@ -7,33 +7,42 @@ exports[`Select.Multiple render not display maxTagPlaceholder if maxTagCount not
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        readonly=""
-        role="combobox"
-        style="opacity: 0;"
-        type="search"
-        unselectable="on"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            readonly=""
+            role="combobox"
+            style="opacity: 0;"
+            type="search"
+            unselectable="on"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
     <span
       class="rc-select-selection-placeholder"
     />
@@ -48,86 +57,110 @@ exports[`Select.Multiple render truncates tags by maxTagCount and show maxTagPla
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-item"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        One
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            One
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        Two
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            Two
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-rest"
+        style="opacity: 1;"
       >
-        <span>
-          Omitted
+        <span
+          class="rc-select-selection-item"
+        >
+          <span
+            class="rc-select-selection-item-content"
+          >
+            <span>
+              Omitted
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
-    >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        readonly=""
-        role="combobox"
-        style="opacity: 0;"
-        type="search"
-        unselectable="on"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            readonly=""
+            role="combobox"
+            style="opacity: 0;"
+            type="search"
+            unselectable="on"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -139,86 +172,110 @@ exports[`Select.Multiple render truncates tags by maxTagCount and show maxTagPla
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-item"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        One
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            One
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        Two
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            Two
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-rest"
+        style="opacity: 1;"
       >
-        <span>
-          1 values omitted
+        <span
+          class="rc-select-selection-item"
+        >
+          <span
+            class="rc-select-selection-item-content"
+          >
+            <span>
+              1 values omitted
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
-    >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        readonly=""
-        role="combobox"
-        style="opacity: 0;"
-        type="search"
-        unselectable="on"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            readonly=""
+            role="combobox"
+            style="opacity: 0;"
+            type="search"
+            unselectable="on"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -230,75 +287,94 @@ exports[`Select.Multiple render truncates values by maxTagTextLength 1`] = `
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-item"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        On...
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            On...
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        Tw...
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            Tw...
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
-    >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        readonly=""
-        role="combobox"
-        style="opacity: 0;"
-        type="search"
-        unselectable="on"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            readonly=""
+            role="combobox"
+            style="opacity: 0;"
+            type="search"
+            unselectable="on"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/tests/__snapshots__/Tags.test.tsx.snap
+++ b/tests/__snapshots__/Tags.test.tsx.snap
@@ -8,73 +8,92 @@ exports[`Select.Tags OptGroup renders correctly 1`] = `
     <div
       class="rc-select-selector"
     >
-      <span
-        class="rc-select-selection-item"
+      <div
+        class="rc-select-selection-overflow"
       >
-        <span
-          class="rc-select-selection-item-content"
-        >
-          Jack
-        </span>
-        <span
-          aria-hidden="true"
-          class="rc-select-selection-item-remove"
-          style="user-select: none;"
-          unselectable="on"
+        <div
+          class="rc-select-selection-overflow-item"
+          style="opacity: 1;"
         >
           <span
-            class="rc-select-selection-item-remove-icon"
+            class="rc-select-selection-item"
           >
-            ×
+            <span
+              class="rc-select-selection-item-content"
+            >
+              Jack
+            </span>
+            <span
+              aria-hidden="true"
+              class="rc-select-selection-item-remove"
+              style="user-select: none;"
+              unselectable="on"
+            >
+              <span
+                class="rc-select-selection-item-remove-icon"
+              >
+                ×
+              </span>
+            </span>
           </span>
-        </span>
-      </span>
-      <span
-        class="rc-select-selection-item"
-      >
-        <span
-          class="rc-select-selection-item-content"
-        >
-          foo
-        </span>
-        <span
-          aria-hidden="true"
-          class="rc-select-selection-item-remove"
-          style="user-select: none;"
-          unselectable="on"
+        </div>
+        <div
+          class="rc-select-selection-overflow-item"
+          style="opacity: 1;"
         >
           <span
-            class="rc-select-selection-item-remove-icon"
+            class="rc-select-selection-item"
           >
-            ×
+            <span
+              class="rc-select-selection-item-content"
+            >
+              foo
+            </span>
+            <span
+              aria-hidden="true"
+              class="rc-select-selection-item-remove"
+              style="user-select: none;"
+              unselectable="on"
+            >
+              <span
+                class="rc-select-selection-item-remove-icon"
+              >
+                ×
+              </span>
+            </span>
           </span>
-        </span>
-      </span>
-      <span
-        class="rc-select-selection-search"
-        style="width: 0px;"
-      >
-        <input
-          aria-activedescendant="rc_select_TEST_OR_SSR_list_1"
-          aria-autocomplete="list"
-          aria-controls="rc_select_TEST_OR_SSR_list"
-          aria-expanded="true"
-          aria-haspopup="listbox"
-          aria-owns="rc_select_TEST_OR_SSR_list"
-          autocomplete="off"
-          class="rc-select-selection-search-input"
-          id="rc_select_TEST_OR_SSR"
-          role="combobox"
-          type="search"
-          value=""
-        />
-        <span
-          aria-hidden="true"
-          class="rc-select-selection-search-mirror"
+        </div>
+        <div
+          class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+          style="opacity: 1;"
         >
-           
-        </span>
-      </span>
+          <div
+            class="rc-select-selection-search"
+            style="width: 0px;"
+          >
+            <input
+              aria-activedescendant="rc_select_TEST_OR_SSR_list_1"
+              aria-autocomplete="list"
+              aria-controls="rc_select_TEST_OR_SSR_list"
+              aria-expanded="true"
+              aria-haspopup="listbox"
+              aria-owns="rc_select_TEST_OR_SSR_list"
+              autocomplete="off"
+              class="rc-select-selection-search-input"
+              id="rc_select_TEST_OR_SSR"
+              role="combobox"
+              type="search"
+              value=""
+            />
+            <span
+              aria-hidden="true"
+              class="rc-select-selection-search-mirror"
+            >
+               
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
     <div>
       <div
@@ -214,30 +233,39 @@ exports[`Select.Tags render not display maxTagPlaceholder if maxTagCount not rea
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        role="combobox"
-        type="search"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            role="combobox"
+            type="search"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
     <span
       class="rc-select-selection-placeholder"
     />
@@ -252,83 +280,107 @@ exports[`Select.Tags render truncates tags by maxTagCount and show maxTagPlaceho
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-item"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        One
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            One
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        Two
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            Two
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-rest"
+        style="opacity: 1;"
       >
-        <span>
-          Omitted
+        <span
+          class="rc-select-selection-item"
+        >
+          <span
+            class="rc-select-selection-item-content"
+          >
+            <span>
+              Omitted
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
-    >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        role="combobox"
-        type="search"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            role="combobox"
+            type="search"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -340,83 +392,107 @@ exports[`Select.Tags render truncates tags by maxTagCount and show maxTagPlaceho
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-item"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        One
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            One
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        Two
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            Two
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-rest"
+        style="opacity: 1;"
       >
-        <span>
-          1 values omitted
+        <span
+          class="rc-select-selection-item"
+        >
+          <span
+            class="rc-select-selection-item-content"
+          >
+            <span>
+              1 values omitted
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
-    >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        role="combobox"
-        type="search"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            role="combobox"
+            type="search"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -428,72 +504,91 @@ exports[`Select.Tags render truncates values by maxTagTextLength 1`] = `
   <div
     class="rc-select-selector"
   >
-    <span
-      class="rc-select-selection-item"
+    <div
+      class="rc-select-selection-overflow"
     >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        On...
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            On...
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-item"
-    >
-      <span
-        class="rc-select-selection-item-content"
-      >
-        Tw...
-      </span>
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-item-remove"
-        style="user-select: none;"
-        unselectable="on"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item"
+        style="opacity: 1;"
       >
         <span
-          class="rc-select-selection-item-remove-icon"
+          class="rc-select-selection-item"
         >
-          ×
+          <span
+            class="rc-select-selection-item-content"
+          >
+            Tw...
+          </span>
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              class="rc-select-selection-item-remove-icon"
+            >
+              ×
+            </span>
+          </span>
         </span>
-      </span>
-    </span>
-    <span
-      class="rc-select-selection-search"
-      style="width: 0px;"
-    >
-      <input
-        aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
-        aria-autocomplete="list"
-        aria-controls="rc_select_TEST_OR_SSR_list"
-        aria-haspopup="listbox"
-        aria-owns="rc_select_TEST_OR_SSR_list"
-        autocomplete="off"
-        class="rc-select-selection-search-input"
-        id="rc_select_TEST_OR_SSR"
-        role="combobox"
-        type="search"
-        value=""
-      />
-      <span
-        aria-hidden="true"
-        class="rc-select-selection-search-mirror"
+      </div>
+      <div
+        class="rc-select-selection-overflow-item rc-select-selection-overflow-item-suffix"
+        style="opacity: 1;"
       >
-         
-      </span>
-    </span>
+        <div
+          class="rc-select-selection-search"
+          style="width: 0px;"
+        >
+          <input
+            aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="rc-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            role="combobox"
+            type="search"
+            value=""
+          />
+          <span
+            aria-hidden="true"
+            class="rc-select-selection-search-mirror"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
动态测量依赖于元素尺寸，移除了节点动画。帮忙测测。另外，动态元素后，inline 对齐可能会有问题，之后如果用户有问题，就直接推荐用 Space。

https://select-git-responsive.react-component.vercel.app/?path=/story/rc-select--tags

第一个例子

(没问题再补测试)