### PR TITLE
fix: correct update option's label when update value (equal label) in options

### DIFF
--- a/src/hooks/useCacheDisplayValue.ts
+++ b/src/hooks/useCacheDisplayValue.ts
@@ -17,7 +17,7 @@ export default function useCacheDisplayValue(
 
     const resultValues = values.map(item => {
       const cacheLabel = valueLabels.get(item.value);
-      if (item.value === item.label && cacheLabel) {
+      if (item.isCacheable && cacheLabel) {
         return {
           ...item,
           label: cacheLabel,

--- a/src/interface/generator.ts
+++ b/src/interface/generator.ts
@@ -13,6 +13,7 @@ export interface LabelValueType {
   key?: Key;
   value?: RawValueType;
   label?: React.ReactNode;
+  isCacheable?: Boolean;
 }
 export type DefaultValueType = RawValueType | RawValueType[] | LabelValueType | LabelValueType[];
 

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -153,6 +153,7 @@ export const getLabeledValue: GetLabeledValue<FlattenOptionData[]> = (
     result.label = item[optionLabelProp];
   } else {
     result.label = value;
+    result.isCacheable = true;
   }
 
   // Used for motion control

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1612,6 +1612,9 @@ describe('Select.Basic', () => {
 
     wrapper.setProps({ options: [] });
     expect(findSelection(wrapper).text()).toEqual('Bamboo');
+
+    wrapper.setProps({ options: [{ value: 903, label: 903 }] });
+    expect(findSelection(wrapper).text()).toEqual('903');
   });
 
   // https://github.com/ant-design/ant-design/issues/24747


### PR DESCRIPTION
Fix ant-design/ant-design#28495, if `item.value === item.label` in options, the true label will be replaced by `cacheLabel`. Add `isCacheable` may help fix this.