### PR TITLE
fix: select TagRender Property not open dropdown when click

### DIFF
--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -26,6 +26,7 @@ interface SelectorProps extends InnerSelectorProps {
   maxTagPlaceholder?: React.ReactNode | ((omittedValues: LabelValueType[]) => React.ReactNode);
   tokenSeparators?: string[];
   tagRender?: (props: CustomTagProps) => React.ReactElement;
+  onToggleOpen: (open?: boolean) => void;
 
   // Motion
   choiceTransitionName?: string;
@@ -62,6 +63,7 @@ const SelectSelector: React.FC<SelectorProps> = props => {
     maxTagTextLength,
     maxTagPlaceholder = (omittedValues: LabelValueType[]) => `+ ${omittedValues.length} ...`,
     tagRender,
+    onToggleOpen,
 
     onSelect,
     onInputChange,
@@ -123,8 +125,13 @@ const SelectSelector: React.FC<SelectorProps> = props => {
     closable: boolean,
     onClose: React.MouseEventHandler,
   ) {
+    const onMouseDown = (e: React.MouseEvent) => {
+      onPreventMouseDown(e);
+      onToggleOpen(true);
+    };
+
     return (
-      <span onMouseDown={onPreventMouseDown}>
+      <span onMouseDown={onMouseDown}>
         {tagRender({
           label: content,
           value,

--- a/tests/Multiple.test.tsx
+++ b/tests/Multiple.test.tsx
@@ -247,7 +247,7 @@ describe('Select.Multiple', () => {
     toggleOpen(wrapper);
     expectOpen(wrapper, false);
     removeSelection(wrapper);
-    expectOpen(wrapper, true);
+    expectOpen(wrapper, false);
     expect(wrapper.find('Selector').props().values).toEqual([
       expect.objectContaining({ value: 2 }),
     ]);

--- a/tests/Multiple.test.tsx
+++ b/tests/Multiple.test.tsx
@@ -247,7 +247,7 @@ describe('Select.Multiple', () => {
     toggleOpen(wrapper);
     expectOpen(wrapper, false);
     removeSelection(wrapper);
-    expectOpen(wrapper, false);
+    expectOpen(wrapper, true);
     expect(wrapper.find('Selector').props().values).toEqual([
       expect.objectContaining({ value: 2 }),
     ]);

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -285,7 +285,9 @@ describe('Select.Tags', () => {
       const wrapper = mount(<Select mode="tags" tokenSeparators={[',']} tagRender={tagRender} />);
 
       wrapper.find('input').simulate('change', { target: { value: '1,A,42' } });
+      wrapper.find('span.A').simulate('mousedown');
 
+      expectOpen(wrapper, true);
       expect(wrapper.find('span.A').length).toBe(1);
       expect(wrapper.find('span.A').text()).toBe('AA');
       expect(onTagRender).toHaveBeenCalled();

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -285,7 +285,7 @@ describe('Select.Tags', () => {
       const wrapper = mount(<Select mode="tags" tokenSeparators={[',']} tagRender={tagRender} />);
 
       wrapper.find('input').simulate('change', { target: { value: '1,A,42' } });
-      wrapper.find('span.A').simulate('mousedown');
+      toggleOpen(wrapper);
 
       expectOpen(wrapper, true);
       expect(wrapper.find('span.A').length).toBe(1);

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -285,7 +285,7 @@ describe('Select.Tags', () => {
       const wrapper = mount(<Select mode="tags" tokenSeparators={[',']} tagRender={tagRender} />);
 
       wrapper.find('input').simulate('change', { target: { value: '1,A,42' } });
-      toggleOpen(wrapper);
+      wrapper.find('span.A').simulate('mousedown');
 
       expectOpen(wrapper, true);
       expect(wrapper.find('span.A').length).toBe(1);


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/28449