### PR TITLE
chore: optimize search performance

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -371,7 +371,7 @@ export default function generateSelector<
     React.useImperativeHandle(ref, () => ({
       focus: selectorRef.current.focus,
       blur: selectorRef.current.blur,
-      scrollTo: listRef.current?.scrollTo,
+      scrollTo: listRef.current?.scrollTo as ScrollTo,
     }));
 
     // ============================= Value ==============================
@@ -380,7 +380,9 @@ export default function generateSelector<
     });
 
     /** Unique raw values */
-    const mergedRawValue = useMemo<RawValueType[]>(
+    const [mergedRawValue, mergedValueMap] = useMemo<
+      [RawValueType[], Map<RawValueType, LabelValueType>]
+    >(
       () =>
         toInnerValue(mergedValue, {
           labelInValue: mergedLabelInValue,
@@ -431,7 +433,7 @@ export default function generateSelector<
       [mergedOptions],
     );
 
-    const getValueOption = useCacheOptions(mergedRawValue, mergedFlattenOptions);
+    const getValueOption = useCacheOptions(mergedFlattenOptions);
 
     // Display options for OptionList
     const displayOptions = useMemo<OptionsType>(() => {
@@ -476,7 +478,7 @@ export default function generateSelector<
         const valueOptions = getValueOption([val]);
         const displayValue = getLabeledValue(val, {
           options: valueOptions,
-          prevValue: mergedValue,
+          prevValueMap: mergedValueMap,
           labelInValue: mergedLabelInValue,
           optionLabelProp: mergedOptionLabelProp,
         });
@@ -511,7 +513,7 @@ export default function generateSelector<
         const selectValue = (mergedLabelInValue
           ? getLabeledValue(newValue, {
               options: newValueOption,
-              prevValue: mergedValue,
+              prevValueMap: mergedValueMap,
               labelInValue: mergedLabelInValue,
               optionLabelProp: mergedOptionLabelProp,
             })
@@ -546,7 +548,7 @@ export default function generateSelector<
         labelInValue: mergedLabelInValue,
         options: newRawValuesOptions,
         getLabeledValue,
-        prevValue: mergedValue,
+        prevValueMap: mergedValueMap,
         optionLabelProp: mergedOptionLabelProp,
       });
 

--- a/src/hooks/useCacheOptions.ts
+++ b/src/hooks/useCacheOptions.ts
@@ -8,7 +8,7 @@ export default function useCacheOptions<
     key?: Key;
     disabled?: boolean;
   }[]
->(values: RawValueType[], options: FlattenOptionsType<OptionsType>) {
+>(options: FlattenOptionsType<OptionsType>) {
   const prevOptionMapRef = React.useRef<Map<RawValueType, FlattenOptionsType<OptionsType>[number]>>(
     null,
   );
@@ -22,7 +22,7 @@ export default function useCacheOptions<
       map.set(value, item);
     });
     return map;
-  }, [values, options]);
+  }, [options]);
 
   prevOptionMapRef.current = optionMap;
 

--- a/src/interface/generator.ts
+++ b/src/interface/generator.ts
@@ -38,7 +38,7 @@ export type GetLabeledValue<FOT extends FlattenOptionsType> = (
   value: RawValueType,
   config: {
     options: FOT;
-    prevValue: DefaultValueType;
+    prevValueMap: Map<RawValueType, LabelValueType>;
     labelInValue: boolean;
     optionLabelProp: string;
   },

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -119,24 +119,14 @@ export function findValueOption(
 
 export const getLabeledValue: GetLabeledValue<FlattenOptionData[]> = (
   value,
-  { options, prevValue, labelInValue, optionLabelProp },
+  { options, prevValueMap, labelInValue, optionLabelProp },
 ) => {
   const item = findValueOption([value], options)[0];
   const result: LabelValueType = {
     value,
   };
 
-  let prevValItem: LabelValueType;
-  const prevValues = toArray<RawValueType | LabelValueType>(prevValue);
-  if (labelInValue) {
-    prevValItem = prevValues.find((prevItem: LabelValueType) => {
-      if (typeof prevItem === 'object' && 'value' in prevItem) {
-        return prevItem.value === value;
-      }
-      // [Legacy] Support `key` as `value`
-      return prevItem.key === value;
-    }) as LabelValueType;
-  }
+  const prevValItem: LabelValueType = labelInValue ? prevValueMap.get(value) : undefined;
 
   if (prevValItem && typeof prevValItem === 'object' && 'label' in prevValItem) {
     result.label = prevValItem.label;


### PR DESCRIPTION
fix https://github.com/react-component/select/issues/564

修改了 `getLabeledValue` 里面的 `find` 改为了 `Map` 获取。

**影响范围：**

getLabeledValue 的 `prevValue` 改为了 `prevValueMap`

toInnerValue 返回值 变成了两个参数 `[RawValueType[], Map<RawValueType, LabelValueType>]`

toOuterValues 的 `prevValue` 改为了 `prevValueMap`

@zombieJ 看看其他组件有没有用到，有没有什么影响？