### PR TITLE
fix: should stopPropagation when pressing esc

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -218,7 +218,9 @@ const OptionList: React.RefForwardingComponent<
         // >>> Close
         case KeyCode.ESC: {
           onToggleOpen(false);
-          event.stopPropagation();
+          if (open) {
+            event.stopPropagation();
+          }
         }
       }
     },

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -218,6 +218,7 @@ const OptionList: React.RefForwardingComponent<
         // >>> Close
         case KeyCode.ESC: {
           onToggleOpen(false);
+          event.stopPropagation();
         }
       }
     },

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -666,7 +666,12 @@ describe('Select.Basic', () => {
   });
 
   it('close on ESC', () => {
-    const wrapper = mount(<Select />);
+    const onKeyDown = jest.fn();
+    const wrapper = mount(
+      <div onKeyDown={onKeyDown}>
+        <Select />
+      </div>,
+    );
     toggleOpen(wrapper);
     wrapper
       .find('input')
@@ -677,6 +682,7 @@ describe('Select.Basic', () => {
 
     expect(wrapper.find('input').props().value).toBe('');
     expectOpen(wrapper, false);
+    expect(onKeyDown).not.toHaveBeenCalled();
   });
 
   it('close after select', () => {

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -682,7 +682,12 @@ describe('Select.Basic', () => {
 
     expect(wrapper.find('input').props().value).toBe('');
     expectOpen(wrapper, false);
-    expect(onKeyDown).not.toHaveBeenCalled();
+    expect(onKeyDown).toHaveBeenCalledTimes(0);
+
+    // should keep propagation when optionList is closed
+    wrapper.simulate('keyDown', { which: KeyCode.ESC });
+    wrapper.update();
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
   });
 
   it('close after select', () => {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/28815

当下拉列表打开时，退出键应该停止冒泡。