### PR TITLE
fix: press the Enter button and an empty tag may appear

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -722,6 +722,10 @@ export default function generateSelector<
     // If menu is open, OptionList will take charge
     // If mode isn't tags, press enter is not meaningful when you can't see any option
     const onSearchSubmit = (searchText: string) => {
+      // prevent empty tags from appearing when you click the Enter button
+      if (!searchText || !searchText.trim()) {
+        return;
+      }
       const newRawValues = Array.from(
         new Set<RawValueType>([...mergedRawValue, searchText]),
       );


### PR DESCRIPTION
fixed the problem of generating empty tags by pressing Enter when nothing was entered.

Link issue: [`<Select />` in tags mode renders empty tag after pressing enter](https://github.com/ant-design/ant-design/issues/29493)

Solution: If the content is empty, return directly.
