### PR TITLE
fix: remove onMouseDown to resolve popover close

### DIFF
--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -4,15 +4,15 @@ import classNames from 'classnames';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 import Overflow from 'rc-overflow';
 import TransBtn from '../TransBtn';
-import {
+import type {
   LabelValueType,
   DisplayLabelValueType,
   RawValueType,
   CustomTagProps,
   DefaultValueType,
 } from '../interface/generator';
-import { RenderNode } from '../interface';
-import { InnerSelectorProps } from '.';
+import type { RenderNode } from '../interface';
+import type { InnerSelectorProps } from '.';
 import Input from './Input';
 import useLayoutEffect from '../hooks/useLayoutEffect';
 
@@ -35,11 +35,7 @@ interface SelectorProps extends InnerSelectorProps {
   onSelect: (value: RawValueType, option: { selected: boolean }) => void;
 }
 
-const onPreventMouseDown = (event: React.MouseEvent) => {
-  event.preventDefault();
-  event.stopPropagation();
-};
-const SelectSelector: React.FC<SelectorProps> = props => {
+const SelectSelector: React.FC<SelectorProps> = (props) => {
   const {
     id,
     prefixCls,
@@ -107,7 +103,6 @@ const SelectSelector: React.FC<SelectorProps> = props => {
         {closable && (
           <TransBtn
             className={`${selectionPrefixCls}-item-remove`}
-            onMouseDown={onPreventMouseDown}
             onClick={onClose}
             customizeIcon={removeIcon}
           >
@@ -125,8 +120,7 @@ const SelectSelector: React.FC<SelectorProps> = props => {
     closable: boolean,
     onClose: React.MouseEventHandler,
   ) {
-    const onMouseDown = (e: React.MouseEvent) => {
-      onPreventMouseDown(e);
+    const onMouseDown = () => {
       onToggleOpen(true);
     };
 

--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -224,15 +224,19 @@ const Selector: React.RefForwardingComponent<RefSelectorProps, SelectorProps> = 
 
   const onMouseDown: React.MouseEventHandler<HTMLElement> = (event) => {
     const inputMouseDown = getInputMouseDown();
-    if (event.target !== inputRef.current && !inputMouseDown) {
-      event.preventDefault();
-    }
+    const tagCloseMouseDown = (event.target as HTMLElement).innerText === '×';
 
-    if ((mode !== 'combobox' && (!showSearch || !inputMouseDown)) || !open) {
-      if (open) {
-        onSearch('', true, false);
+    if (!tagCloseMouseDown) {
+      if (event.target !== inputRef.current && !inputMouseDown) {
+        event.preventDefault();
       }
-      onToggleOpen();
+
+      if ((mode !== 'combobox' && (!showSearch || !inputMouseDown)) || !open) {
+        if (open) {
+          onSearch('', true, false);
+        }
+        onToggleOpen();
+      }
     }
   };
 

--- a/tests/utils/common.ts
+++ b/tests/utils/common.ts
@@ -15,10 +15,7 @@ export function toggleOpen(wrapper: any) {
 }
 
 export function selectItem(wrapper: any, index: number = 0) {
-  wrapper
-    .find('div.rc-select-item-option-content')
-    .at(index)
-    .simulate('click');
+  wrapper.find('div.rc-select-item-option-content').at(index).simulate('click');
 }
 
 export function findSelection(wrapper: any, index: number = 0) {
@@ -33,17 +30,13 @@ export function findSelection(wrapper: any, index: number = 0) {
 }
 
 export function removeSelection(wrapper: any, index: number = 0) {
-  const preventDefault = jest.fn();
-
   wrapper
     .find('.rc-select-selection-item')
     .at(index)
     .find('.rc-select-selection-item-remove')
     .last()
-    .simulate('mousedown', { preventDefault })
-    .simulate('click');
-
-  expect(preventDefault).toHaveBeenCalled();
+    .simulate('click')
+    .simulate('mousedown');
 }
 
 type Jest = typeof jest;


### PR DESCRIPTION
存在场景，当 Popover 内有 Modal 框，Modal 框内存在 Select 组件，为 Tag 模式，此时点击标签的 x 号会导致 Popover 被关闭。

Demo:
https://codesandbox.io/s/congfucengneiguanbi-antd4141-forked-e1bcd?file=/index.js

此 PR 允许标签的关闭按钮冒泡到 rc-trigger 的 onPopupMouseDown:
https://github.com/react-component/trigger/blob/89eefdb148ee68e4bbfe5b5b2887ceaff6b2e42c/src/index.tsx#L386

在如下判断中生效：
https://github.com/react-component/trigger/blob/89eefdb148ee68e4bbfe5b5b2887ceaff6b2e42c/src/index.tsx#L410

修复问题。