### PR TITLE
fix: select TagRender prop does not close dropdown when clicked when dropdown is open

### DIFF
--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -127,7 +127,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
   ) {
     const onMouseDown = (e: React.MouseEvent) => {
       onPreventMouseDown(e);
-      onToggleOpen(true);
+      onToggleOpen(!open);
     };
 
     return (

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -295,6 +295,9 @@ describe('Select.Tags', () => {
       expect(wrapper.find('span.A').text()).toBe('AA');
       expect(onTagRender).toHaveBeenCalled();
       expect(wrapper.find('.customize-tag')).toHaveLength(3);
+
+      wrapper.find('span.A').simulate('mousedown');
+      expectOpen(wrapper, false);
     });
 
     it('disabled', () => {


### PR DESCRIPTION
fixes https://github.com/ant-design/ant-design/issues/30220

continuation of https://github.com/react-component/select/pull/582

closes dropdown when it is open when clicking a custom TagRender prop