### PR TITLE
feat: Support `fieldNames`

### DIFF
--- a/examples/singleFieldNames.tsx
+++ b/examples/singleFieldNames.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+import React from 'react';
+import Select from '../src';
+import '../assets/index.less';
+import './single.less';
+
+export default () => {
+  return (
+    <Select
+      style={{ width: 500 }}
+      onChange={console.log}
+      fieldNames={{
+        label: 'fieldLabel',
+        value: 'fieldValue',
+        options: 'fieldOptions',
+      }}
+      options={
+        [
+          {
+            fieldLabel: 'Group',
+            fieldOptions: [
+              {
+                fieldLabel: 'Bamboo',
+                fieldValue: 'bamboo',
+              },
+              {
+                fieldLabel: 'Light',
+                fieldValue: 'light',
+              },
+            ],
+          },
+        ] as any
+      }
+    />
+  );
+};
+/* eslint-enable */

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import KeyCode from 'rc-util/lib/KeyCode';
+import omit from 'rc-util/lib/omit';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 import useMemo from 'rc-util/lib/hooks/useMemo';
 import classNames from 'classnames';
@@ -12,13 +13,16 @@ import type {
   OptionData,
   RenderNode,
   OnActiveValue,
+  FieldNames,
 } from './interface';
 import type { RawValueType, FlattenOptionsType } from './interface/generator';
+import { fillFieldNames } from './utils/valueUtil';
 
 export interface OptionListProps<OptionsType extends object[]> {
   prefixCls: string;
   id: string;
   options: OptionsType;
+  fieldNames?: FieldNames;
   flattenOptions: FlattenOptionsType<OptionsType>;
   height: number;
   itemHeight: number;
@@ -59,6 +63,7 @@ const OptionList: React.RefForwardingComponent<
   {
     prefixCls,
     id,
+    fieldNames,
     flattenOptions,
     childrenAsData,
     values,
@@ -246,7 +251,9 @@ const OptionList: React.RefForwardingComponent<
     );
   }
 
-  function renderItem(index: number) {
+  const omitFieldNameList = Object.keys(fillFieldNames(fieldNames));
+
+  const renderItem = (index: number) => {
     const item = memoFlattenOptions[index];
     if (!item) return null;
 
@@ -266,7 +273,7 @@ const OptionList: React.RefForwardingComponent<
         {value}
       </div>
     ) : null;
-  }
+  };
 
   return (
     <>
@@ -287,8 +294,8 @@ const OptionList: React.RefForwardingComponent<
         virtual={virtual}
         onMouseEnter={onMouseEnter}
       >
-        {({ group, groupOption, data }, itemIndex) => {
-          const { label, key } = data;
+        {({ group, groupOption, data, label, value }, itemIndex) => {
+          const { key } = data;
 
           // Group
           if (group) {
@@ -299,15 +306,8 @@ const OptionList: React.RefForwardingComponent<
             );
           }
 
-          const {
-            disabled,
-            value,
-            title,
-            children,
-            style,
-            className,
-            ...otherProps
-          } = data as OptionData;
+          const { disabled, title, children, style, className, ...otherProps } = data as OptionData;
+          const passedProps = omit(otherProps, omitFieldNameList);
 
           // Option
           const selected = values.has(value);
@@ -337,7 +337,7 @@ const OptionList: React.RefForwardingComponent<
 
           return (
             <div
-              {...otherProps}
+              {...passedProps}
               aria-selected={selected}
               className={optionClassName}
               title={optionTitle}

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -251,7 +251,7 @@ const OptionList: React.RefForwardingComponent<
     );
   }
 
-  const omitFieldNameList = Object.keys(fillFieldNames(fieldNames));
+  const omitFieldNameList = Object.values(fillFieldNames(fieldNames));
 
   const renderItem = (index: number) => {
     const item = memoFlattenOptions[index];

--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -19,7 +19,7 @@ import type { RefSelectorProps } from './Selector';
 import Selector from './Selector';
 import type { RefTriggerProps } from './SelectTrigger';
 import SelectTrigger from './SelectTrigger';
-import type { RenderNode, Mode, RenderDOMFunc, OnActiveValue } from './interface';
+import type { RenderNode, Mode, RenderDOMFunc, OnActiveValue, FieldNames } from './interface';
 import type {
   GetLabeledValue,
   FilterOptions,
@@ -83,6 +83,9 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   labelInValue?: boolean;
   /** Config max length of input. This is only work when `mode` is `combobox` */
   maxLength?: number;
+
+  // Field
+  fieldNames?: FieldNames;
 
   // Search
   inputValue?: string;
@@ -275,6 +278,8 @@ export default function generateSelector<
       optionFilterProp = 'value',
       autoClearSearchValue = true,
       onSearch,
+
+      fieldNames,
 
       // Icons
       allowClear,
@@ -961,6 +966,7 @@ export default function generateSelector<
         open={mergedOpen}
         childrenAsData={!options}
         options={displayOptions}
+        fieldNames={fieldNames}
         flattenOptions={displayFlattenOptions}
         multiple={isMultiple}
         values={rawValues}

--- a/src/hooks/useCacheOptions.ts
+++ b/src/hooks/useCacheOptions.ts
@@ -16,9 +16,7 @@ export default function useCacheOptions<
   const optionMap = React.useMemo(() => {
     const map: Map<RawValueType, FlattenOptionsType<OptionsType>[number]> = new Map();
     options.forEach((item) => {
-      const {
-        data: { value },
-      } = item;
+      const { value } = item;
       map.set(value, item);
     });
     return map;
@@ -26,8 +24,8 @@ export default function useCacheOptions<
 
   prevOptionMapRef.current = optionMap;
 
-  const getValueOption = (vals: RawValueType[]): FlattenOptionsType<OptionsType> =>
-    vals.map((value) => prevOptionMapRef.current.get(value)).filter(Boolean);
+  const getValueOption = (valueList: RawValueType[]): FlattenOptionsType<OptionsType> =>
+    valueList.map((value) => prevOptionMapRef.current.get(value)).filter(Boolean);
 
   return getValueOption;
 }

--- a/src/interface/generator.ts
+++ b/src/interface/generator.ts
@@ -65,6 +65,8 @@ export declare function RefSelectFunc<OptionsType extends object[], ValueType>(
 export type FlattenOptionsType<OptionsType extends object[] = object[]> = {
   key: Key;
   data: OptionsType[number];
+  label?: React.ReactNode;
+  value?: RawValueType;
   /** Used for customize data */
   [name: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }[];

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -8,6 +8,12 @@ export type RenderNode = React.ReactNode | ((props: any) => React.ReactNode);
 export type Mode = 'multiple' | 'tags' | 'combobox';
 
 // ======================== Option ========================
+export interface FieldNames {
+  value?: string;
+  label?: string;
+  options?: string;
+}
+
 export type OnActiveValue = (
   active: RawValueType,
   index: number,
@@ -49,4 +55,6 @@ export interface FlattenOptionData {
   groupOption?: boolean;
   key: string | number;
   data: OptionData | OptionGroupData;
+  label?: React.ReactNode;
+  value?: React.Key;
 }

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -143,7 +143,7 @@ export function findValueOption(
 export const getLabeledValue: GetLabeledValue<FlattenOptionData[]> = (
   value,
   { options, prevValueMap, labelInValue, optionLabelProp },
-) => {
+): LabelValueType => {
   const item = findValueOption([value], options)[0];
   const result: LabelValueType = {
     value,

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -60,12 +60,16 @@ export function flattenOptions(
 
   function dig(list: SelectOptionsType, isGroupOption: boolean) {
     list.forEach((data) => {
-      if (isGroupOption || !('options' in data)) {
+      const label = data[fieldLabel];
+
+      if (isGroupOption || !(fieldOptions in data)) {
         // Option
         flattenList.push({
           key: getKey(data, flattenList.length),
           groupOption: isGroupOption,
           data,
+          label,
+          value: data[fieldValue],
         });
       } else {
         // Option Group
@@ -73,8 +77,7 @@ export function flattenOptions(
           key: getKey(data, flattenList.length),
           group: true,
           data,
-          label: data[fieldLabel],
-          value: data[fieldValue],
+          label,
         });
 
         dig(data[fieldOptions], true);

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -4,6 +4,7 @@ import type {
   OptionData,
   OptionGroupData,
   FlattenOptionData,
+  FieldNames,
 } from '../interface';
 import type {
   LabelValueType,
@@ -32,13 +33,30 @@ function getKey(data: OptionData | OptionGroupData, index: number) {
   return `rc-index-key-${index}`;
 }
 
+export function fillFieldNames(fieldNames?: FieldNames) {
+  const { label, value, options } = fieldNames || {};
+
+  return {
+    label: label || 'label',
+    value: value || 'value',
+    options: options || 'options',
+  };
+}
+
 /**
  * Flat options into flatten list.
  * We use `optionOnly` here is aim to avoid user use nested option group.
  * Here is simply set `key` to the index if not provided.
  */
-export function flattenOptions(options: SelectOptionsType): FlattenOptionData[] {
+export function flattenOptions(
+  options: SelectOptionsType,
+  { fieldNames }: { fieldNames?: FieldNames } = {},
+): FlattenOptionData[] {
   const flattenList: FlattenOptionData[] = [];
+
+  const { label: fieldLabel, value: fieldValue, options: fieldOptions } = fillFieldNames(
+    fieldNames,
+  );
 
   function dig(list: SelectOptionsType, isGroupOption: boolean) {
     list.forEach((data) => {
@@ -55,9 +73,11 @@ export function flattenOptions(options: SelectOptionsType): FlattenOptionData[] 
           key: getKey(data, flattenList.length),
           group: true,
           data,
+          label: data[fieldLabel],
+          value: data[fieldValue],
         });
 
-        dig(data.options, true);
+        dig(data[fieldOptions], true);
       }
     });
   }

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -54,9 +54,11 @@ export function flattenOptions(
 ): FlattenOptionData[] {
   const flattenList: FlattenOptionData[] = [];
 
-  const { label: fieldLabel, value: fieldValue, options: fieldOptions } = fillFieldNames(
-    fieldNames,
-  );
+  const {
+    label: fieldLabel,
+    value: fieldValue,
+    options: fieldOptions,
+  } = fillFieldNames(fieldNames);
 
   function dig(list: SelectOptionsType, isGroupOption: boolean) {
     list.forEach((data) => {
@@ -117,11 +119,10 @@ export function findValueOption(
 ): OptionData[] {
   const optionMap: Map<RawValueType, OptionData> = new Map();
 
-  options.forEach((flattenItem) => {
-    if (!flattenItem.group) {
-      const data = flattenItem.data as OptionData;
+  options.forEach(({ data, group, value }) => {
+    if (!group) {
       // Check if match
-      optionMap.set(data.value, data);
+      optionMap.set(value, data as OptionData);
     }
   });
 

--- a/tests/Field.test.tsx
+++ b/tests/Field.test.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable import/no-named-as-default-member */
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import * as React from 'react';
+import Select from '../src';
+import { injectRunAllTimers } from './utils/common';
+
+describe('Select.Field', () => {
+  injectRunAllTimers(jest);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fieldNames should work', () => {
+    // Use special name to avoid compatible match
+    const wrapper = mount(
+      <Select
+        open
+        options={
+          [
+            {
+              bambooLabel: 'Bamboo',
+              bambooChildren: [
+                { bambooLabel: 'Light', bambooValue: 'light' },
+                { bambooLabel: 'Little', bambooValue: 'little' },
+              ],
+            },
+          ] as any
+        }
+        fieldNames={{
+          label: 'bambooLabel',
+          value: 'bambooValue',
+          children: 'bambooChildren',
+        }}
+      />,
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // expect(wrapper.);
+    console.log('>>>', wrapper.find('.rc-virtual-list-holder-inner').html());
+  });
+});

--- a/tests/Field.test.tsx
+++ b/tests/Field.test.tsx
@@ -17,10 +17,12 @@ describe('Select.Field', () => {
   });
 
   it('fieldNames should work', () => {
-    // Use special name to avoid compatible match
+    const onChange = jest.fn();
+
     const wrapper = mount(
       <Select
         open
+        onChange={onChange}
         options={
           [
             {
@@ -35,7 +37,7 @@ describe('Select.Field', () => {
         fieldNames={{
           label: 'bambooLabel',
           value: 'bambooValue',
-          children: 'bambooChildren',
+          options: 'bambooChildren',
         }}
       />,
     );
@@ -44,7 +46,13 @@ describe('Select.Field', () => {
       jest.runAllTimers();
     });
 
-    // expect(wrapper.);
-    console.log('>>>', wrapper.find('.rc-virtual-list-holder-inner').html());
+    // Label match
+    expect(wrapper.find('.rc-select-item-group').text()).toEqual('Bamboo');
+    expect(wrapper.find('.rc-select-item-option').first().text()).toEqual('Light');
+    expect(wrapper.find('.rc-select-item-option').last().text()).toEqual('Little');
+
+    // Click
+    wrapper.find('.rc-select-item-option-content').last().simulate('click');
+    expect(onChange).toHaveBeenCalledWith(2333);
   });
 });

--- a/tests/Field.test.tsx
+++ b/tests/Field.test.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import * as React from 'react';
 import Select from '../src';
+import type { SelectProps } from '../src';
 import { injectRunAllTimers } from './utils/common';
 
 describe('Select.Field', () => {
@@ -16,21 +17,18 @@ describe('Select.Field', () => {
     jest.useRealTimers();
   });
 
-  it('fieldNames should work', () => {
-    const onChange = jest.fn();
+  const OPTION_1 = { bambooLabel: 'Light', bambooValue: 'light' };
+  const OPTION_2 = { bambooLabel: 'Little', bambooValue: 'little' };
 
-    const wrapper = mount(
+  function mountSelect(props?: Partial<SelectProps<any>>) {
+    return mount(
       <Select
         open
-        onChange={onChange}
         options={
           [
             {
               bambooLabel: 'Bamboo',
-              bambooChildren: [
-                { bambooLabel: 'Light', bambooValue: 'light' },
-                { bambooLabel: 'Little', bambooValue: 'little' },
-              ],
+              bambooChildren: [OPTION_1, OPTION_2],
             },
           ] as any
         }
@@ -39,8 +37,16 @@ describe('Select.Field', () => {
           value: 'bambooValue',
           options: 'bambooChildren',
         }}
+        {...props}
       />,
     );
+  }
+
+  it('fieldNames should work', () => {
+    const onChange = jest.fn();
+    const onSelect = jest.fn();
+
+    const wrapper = mountSelect({ onChange, onSelect });
 
     act(() => {
       jest.runAllTimers();
@@ -53,6 +59,21 @@ describe('Select.Field', () => {
 
     // Click
     wrapper.find('.rc-select-item-option-content').last().simulate('click');
-    expect(onChange).toHaveBeenCalledWith(2333);
+    expect(onChange).toHaveBeenCalledWith('little', OPTION_2);
+    expect(onSelect).toHaveBeenCalledWith('little', OPTION_2);
+  });
+
+  it('multiple', () => {
+    const onChange = jest.fn();
+    const wrapper = mountSelect({ mode: 'multiple', onChange });
+
+    // First one
+    wrapper.find('.rc-select-item-option-content').first().simulate('click');
+    expect(onChange).toHaveBeenCalledWith(['light'], [OPTION_1]);
+
+    // Last one
+    onChange.mockReset();
+    wrapper.find('.rc-select-item-option-content').last().simulate('click');
+    expect(onChange).toHaveBeenCalledWith(['light', 'little'], [OPTION_1, OPTION_2]);
   });
 });


### PR DESCRIPTION
感觉上游 `rc-tree-select` 还是需要锁一下版本，否则这种 breaking 改动不好处理。准备发个大版本之后全部锁 minor。

另外，和 @PeachScript 聊了一下 mono repo 改造成本略大，issue 和 PR 也需要迁移。可以走 git 子模块形式，但是需要自己搞一个版本依赖管理的东东。晚点我再研究研究。

ref https://github.com/ant-design/ant-design/issues/24282