### PR TITLE
fix: onChange 参数可以为 `undefined`

### DIFF
--- a/src/generate.tsx
+++ b/src/generate.tsx
@@ -160,7 +160,7 @@ export interface SelectProps<OptionsType extends object[], ValueType> extends Re
   onDeselect?: (value: SingleType<ValueType>, option: OptionsType[number]) => void;
   onInputKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   onClick?: React.MouseEventHandler;
-  onChange?: (value: ValueType, option: OptionsType[number] | OptionsType) => void;
+  onChange?: (value: ValueType, option: OptionsType[number] | OptionsType | undefined) => void;
   onBlur?: React.FocusEventHandler<HTMLElement>;
   onFocus?: React.FocusEventHandler<HTMLElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;

--- a/src/interface/generator.ts
+++ b/src/interface/generator.ts
@@ -15,7 +15,7 @@ export interface LabelValueType {
   label?: React.ReactNode;
   isCacheable?: boolean;
 }
-export type DefaultValueType = RawValueType | RawValueType[] | LabelValueType | LabelValueType[];
+export type DefaultValueType = RawValueType | RawValueType[] | LabelValueType | LabelValueType[] | undefined;
 
 export interface DisplayLabelValueType extends LabelValueType {
   disabled?: boolean;


### PR DESCRIPTION
## This is

- [x] bug fix
- [x] TypeScript definition update


## Background and solution

select 的 onChange 参数定义的类型不能为 `undefined`，但是当显示 `clear` icon，并点击清空选项时，会调用 `onChange` 事件，通过 `console.log` 打印出来的 `value` 和  `option` 为 `undefined`

```typescript
function CustomSelect({ children, ...rest }: SelectProps) {
  return (
    <>
      <Select
        {...rest}
        onChange={(value, option) => {
          // 提示类型都不能为 undefined，
          // 但是当点击 clear icon 时，打印出的 value 和 option 为 undefined
          console.log(value, option);
          rest.onChange?.(value, option);
        }}
      >
        {children}
      </Select>
      <button
        onClick={() => {
          rest.onChange?.(undefined, []); // 类型错误，提示 value 不能为 undefined
          rest.onChange?.("male", undefined); // 类型错误 option 不能为 undefined
        }}
      >
        扩展按钮
      </button>
    </>
  );
}

``` 

##  demo

https://codesandbox.io/s/gallant-worker-ik998?file=/src/App.tsx