### PR TITLE
fix ant-design #33281: when select close, some key down will open the…

### DIFF
--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -16,6 +16,7 @@ import MultipleSelector from './MultipleSelector';
 import SingleSelector from './SingleSelector';
 import useLock from '../hooks/useLock';
 import type { CustomTagProps, DisplayValueType, Mode, RenderNode } from '../BaseSelect';
+import { isValidateOpenKey } from '../utils/keyUtil';
 
 export interface InnerSelectorProps {
   prefixCls: string;
@@ -143,7 +144,7 @@ const Selector: React.RefForwardingComponent<RefSelectorProps, SelectorProps> = 
       onSearchSubmit?.((event.target as HTMLInputElement).value);
     }
 
-    if (![KeyCode.SHIFT, KeyCode.TAB, KeyCode.BACKSPACE, KeyCode.ESC].includes(which)) {
+    if (isValidateOpenKey(which)) {
       onToggleOpen(true);
     }
   };

--- a/src/utils/keyUtil.ts
+++ b/src/utils/keyUtil.ts
@@ -1,0 +1,34 @@
+import KeyCode from 'rc-util/lib/KeyCode';
+
+/** keyCode Judgment function */
+export function isValidateOpenKey(currentKeyCode: number): boolean {
+  return ![
+    // System function button
+    KeyCode.ESC,
+    KeyCode.SHIFT,
+    KeyCode.BACKSPACE,
+    KeyCode.TAB,
+    KeyCode.WIN_KEY,
+    KeyCode.ALT,
+    KeyCode.META,
+    KeyCode.WIN_KEY_RIGHT,
+    KeyCode.CTRL,
+    KeyCode.SEMICOLON,
+    KeyCode.EQUALS,
+    KeyCode.CAPS_LOCK,
+    KeyCode.CONTEXT_MENU,
+    // F1-F12
+    KeyCode.F1,
+    KeyCode.F2,
+    KeyCode.F3,
+    KeyCode.F4,
+    KeyCode.F5,
+    KeyCode.F6,
+    KeyCode.F7,
+    KeyCode.F8,
+    KeyCode.F9,
+    KeyCode.F10,
+    KeyCode.F11,
+    KeyCode.F12,
+  ].includes(currentKeyCode);
+}

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -696,6 +696,47 @@ describe('Select.Basic', () => {
     expect(onKeyDown).toHaveBeenCalledTimes(1);
   });
 
+  it('not open when system key down', () => {
+    const wrapper = mount(
+      <Select>
+        <Option value="1">1</Option>
+        <Option value="2">2</Option>
+      </Select>,
+    );
+
+    wrapper
+      .find('input')
+      .simulate('keyDown', { which: KeyCode.ESC })
+      .simulate('keyDown', { which: KeyCode.SHIFT })
+      .simulate('keyDown', { which: KeyCode.BACKSPACE })
+      .simulate('keyDown', { which: KeyCode.TAB })
+      .simulate('keyDown', { which: KeyCode.WIN_KEY })
+      .simulate('keyDown', { which: KeyCode.ALT })
+      .simulate('keyDown', { which: KeyCode.META })
+      .simulate('keyDown', { which: KeyCode.WIN_KEY_RIGHT })
+      .simulate('keyDown', { which: KeyCode.CTRL })
+      .simulate('keyDown', { which: KeyCode.SEMICOLON })
+      .simulate('keyDown', { which: KeyCode.EQUALS })
+      .simulate('keyDown', { which: KeyCode.CAPS_LOCK })
+      .simulate('keyDown', { which: KeyCode.CONTEXT_MENU })
+      .simulate('keyDown', { which: KeyCode.F1 })
+      .simulate('keyDown', { which: KeyCode.F2 })
+      .simulate('keyDown', { which: KeyCode.F3 })
+      .simulate('keyDown', { which: KeyCode.F4 })
+      .simulate('keyDown', { which: KeyCode.F5 })
+      .simulate('keyDown', { which: KeyCode.F6 })
+      .simulate('keyDown', { which: KeyCode.F7 })
+      .simulate('keyDown', { which: KeyCode.F8 })
+      .simulate('keyDown', { which: KeyCode.F9 })
+      .simulate('keyDown', { which: KeyCode.F10 })
+      .simulate('keyDown', { which: KeyCode.F11 })
+      .simulate('keyDown', { which: KeyCode.F12 });
+    expectOpen(wrapper, false);
+
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.NUM_ONE });
+    expectOpen(wrapper, true);
+  });
+
   it('close after select', () => {
     const wrapper = mount(
       <Select>


### PR DESCRIPTION
fix the Ant Design-Issue [#33281](https://github.com/ant-design/ant-design/issues/33281)
**What I do?**
1. add judgment when the select closed
2. move the openSelect judgment to the keyUtils,
   * reason: Prevent the judgment logic from polluting components

**我做了什么？**
1. 增加判断当选择框关闭的时候
2. 将判断函数抽象移动至keyUtils
   * 原因：防止大量判断污染组件