### PR TITLE
fix: auto dropdown placement

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -301,12 +301,15 @@
   }
 
   &-slide-up-enter&-slide-up-enter-active&-placement-bottomLeft,
-  &-slide-up-appear&-slide-up-appear-active&-placement-bottomLeft {
+  &-slide-up-appear&-slide-up-appear-active&-placement-bottomLeft,
+  &-slide-up-enter&-slide-up-enter-active&-placement-bottomRight,
+  &-slide-up-appear&-slide-up-appear-active&-placement-bottomRight {
     animation-name: rcSelectDropdownSlideUpIn;
     animation-play-state: running;
   }
 
-  &-slide-up-leave&-slide-up-leave-active&-placement-bottomLeft {
+  &-slide-up-leave&-slide-up-leave-active&-placement-bottomLeft,
+  &-slide-up-leave&-slide-up-leave-active&-placement-bottomRight {
     animation-name: rcSelectDropdownSlideUpOut;
     animation-play-state: running;
   }

--- a/docs/examples/single-animation.tsx
+++ b/docs/examples/single-animation.tsx
@@ -17,10 +17,13 @@ const Test = () => (
         allowClear
         placeholder="placeholder"
         defaultValue="lucy"
-        style={{ width: 500 }}
+        style={{ width: '100%' }}
         animation="slide-up"
         showSearch
         onChange={onChange}
+        dropdownStyle={{
+          width: 'auto',
+        }}
       >
         <Option value="jack">
           <b

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -165,7 +165,7 @@ const Select = React.forwardRef(
       // Select
       onSelect,
       onDeselect,
-      dropdownMatchSelectWidth,
+      dropdownMatchSelectWidth = true,
 
       // Options
       filterOption,

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -3,39 +3,43 @@ import Trigger from 'rc-trigger';
 import classNames from 'classnames';
 import type { Placement, RenderDOMFunc } from './BaseSelect';
 
-const BUILT_IN_PLACEMENTS = {
-  bottomLeft: {
-    points: ['tl', 'bl'],
-    offset: [0, 4],
-    overflow: {
-      adjustX: 1,
-      adjustY: 1,
+const getBuiltInPlacements = (dropdownMatchSelectWidth: number | boolean) => {
+  // Enable horizontal overflow auto-adjustment when a custom dropdown width is provided
+  const adjustX = dropdownMatchSelectWidth === true ? 0 : 1;
+  return {
+    bottomLeft: {
+      points: ['tl', 'bl'],
+      offset: [0, 4],
+      overflow: {
+        adjustX,
+        adjustY: 1,
+      },
     },
-  },
-  bottomRight: {
-    points: ['tr', 'br'],
-    offset: [0, 4],
-    overflow: {
-      adjustX: 1,
-      adjustY: 1,
+    bottomRight: {
+      points: ['tr', 'br'],
+      offset: [0, 4],
+      overflow: {
+        adjustX,
+        adjustY: 1,
+      },
     },
-  },
-  topLeft: {
-    points: ['bl', 'tl'],
-    offset: [0, -4],
-    overflow: {
-      adjustX: 1,
-      adjustY: 1,
+    topLeft: {
+      points: ['bl', 'tl'],
+      offset: [0, -4],
+      overflow: {
+        adjustX,
+        adjustY: 1,
+      },
     },
-  },
-  topRight: {
-    points: ['br', 'tr'],
-    offset: [0, -4],
-    overflow: {
-      adjustX: 1,
-      adjustY: 1,
+    topRight: {
+      points: ['br', 'tr'],
+      offset: [0, -4],
+      overflow: {
+        adjustX,
+        adjustY: 1,
+      },
     },
-  },
+  };
 };
 
 export interface RefTriggerProps {
@@ -85,7 +89,7 @@ const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTrigger
     dropdownClassName,
     direction = 'ltr',
     placement,
-    dropdownMatchSelectWidth = true,
+    dropdownMatchSelectWidth,
     dropdownRender,
     dropdownAlign,
     getPopupContainer,
@@ -102,6 +106,11 @@ const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTrigger
   if (dropdownRender) {
     popupNode = dropdownRender(popupElement);
   }
+
+  const builtInPlacements = React.useMemo(
+    () => getBuiltInPlacements(dropdownMatchSelectWidth),
+    [dropdownMatchSelectWidth],
+  );
 
   // ===================== Motion ======================
   const mergedTransitionName = animation ? `${dropdownPrefixCls}-${animation}` : transitionName;
@@ -130,7 +139,7 @@ const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTrigger
       showAction={onPopupVisibleChange ? ['click'] : []}
       hideAction={onPopupVisibleChange ? ['click'] : []}
       popupPlacement={placement || (direction === 'rtl' ? 'bottomRight' : 'bottomLeft')}
-      builtinPlacements={BUILT_IN_PLACEMENTS}
+      builtinPlacements={builtInPlacements}
       prefixCls={dropdownPrefixCls}
       popupTransitionName={mergedTransitionName}
       popup={

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -3,49 +3,40 @@ import Trigger from 'rc-trigger';
 import classNames from 'classnames';
 import type { Placement, RenderDOMFunc } from './BaseSelect';
 
-const getBuiltInPlacements = (adjustX: number) => {
-  return {
-    bottomLeft: {
-      points: ['tl', 'bl'],
-      offset: [0, 4],
-      overflow: {
-        adjustX,
-        adjustY: 1,
-      },
+const BUILT_IN_PLACEMENTS = {
+  bottomLeft: {
+    points: ['tl', 'bl'],
+    offset: [0, 4],
+    overflow: {
+      adjustX: 1,
+      adjustY: 1,
     },
-    bottomRight: {
-      points: ['tr', 'br'],
-      offset: [0, 4],
-      overflow: {
-        adjustX,
-        adjustY: 1,
-      },
+  },
+  bottomRight: {
+    points: ['tr', 'br'],
+    offset: [0, 4],
+    overflow: {
+      adjustX: 1,
+      adjustY: 1,
     },
-    topLeft: {
-      points: ['bl', 'tl'],
-      offset: [0, -4],
-      overflow: {
-        adjustX,
-        adjustY: 1,
-      },
+  },
+  topLeft: {
+    points: ['bl', 'tl'],
+    offset: [0, -4],
+    overflow: {
+      adjustX: 1,
+      adjustY: 1,
     },
-    topRight: {
-      points: ['br', 'tr'],
-      offset: [0, -4],
-      overflow: {
-        adjustX,
-        adjustY: 1,
-      },
+  },
+  topRight: {
+    points: ['br', 'tr'],
+    offset: [0, -4],
+    overflow: {
+      adjustX: 1,
+      adjustY: 1,
     },
-  };
+  },
 };
-
-const getAdjustX = (adjustXDependencies: Pick<SelectTriggerProps, 'autoAdjustOverflow' | 'dropdownMatchSelectWidth'>) => {
-  const { autoAdjustOverflow, dropdownMatchSelectWidth } = adjustXDependencies;
-  if(!!autoAdjustOverflow) return 1;
-  // Enable horizontal overflow auto-adjustment when a custom dropdown width is provided
-  return typeof dropdownMatchSelectWidth !== 'number' ? 0 : 1
-}
 
 export interface RefTriggerProps {
   getPopupElement: () => HTMLDivElement;
@@ -70,7 +61,6 @@ export interface SelectTriggerProps {
   getPopupContainer?: RenderDOMFunc;
   dropdownAlign: object;
   empty: boolean;
-  autoAdjustOverflow?: boolean;
 
   getTriggerDOMNode: () => HTMLElement;
   onPopupVisibleChange?: (visible: boolean) => void;
@@ -103,7 +93,6 @@ const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTrigger
     getTriggerDOMNode,
     onPopupVisibleChange,
     onPopupMouseEnter,
-    autoAdjustOverflow,
     ...restProps
   } = props;
 
@@ -113,14 +102,6 @@ const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTrigger
   if (dropdownRender) {
     popupNode = dropdownRender(popupElement);
   }
-
-  const builtInPlacements = React.useMemo(
-    () => getBuiltInPlacements(getAdjustX({
-      autoAdjustOverflow,
-      dropdownMatchSelectWidth,
-    })),
-    [dropdownMatchSelectWidth, autoAdjustOverflow],
-  );
 
   // ===================== Motion ======================
   const mergedTransitionName = animation ? `${dropdownPrefixCls}-${animation}` : transitionName;
@@ -149,7 +130,7 @@ const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTrigger
       showAction={onPopupVisibleChange ? ['click'] : []}
       hideAction={onPopupVisibleChange ? ['click'] : []}
       popupPlacement={placement || (direction === 'rtl' ? 'bottomRight' : 'bottomLeft')}
-      builtinPlacements={builtInPlacements}
+      builtinPlacements={BUILT_IN_PLACEMENTS}
       prefixCls={dropdownPrefixCls}
       popupTransitionName={mergedTransitionName}
       popup={

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1300,7 +1300,9 @@ describe('Select.Basic', () => {
         <Option value={1}>1</Option>
       </Select>,
     );
-    expect(wrapper.find('Trigger').props().builtinPlacements.bottomLeft.overflow.adjustX).toBe(1);
+    expect(
+      (wrapper.find('Trigger').prop('builtinPlacements') as any).bottomLeft.overflow.adjustX,
+    ).toBe(1);
   });
 
   it('dropdown should not auto-adjust horizontally when dropdownMatchSelectWidth is true', () => {
@@ -1310,7 +1312,9 @@ describe('Select.Basic', () => {
         <Option value={1}>1</Option>
       </Select>,
     );
-    expect(wrapper.find('Trigger').props().builtinPlacements.bottomLeft.overflow.adjustX).toBe(0);
+    expect(
+      (wrapper.find('Trigger').prop('builtinPlacements') as any).bottomLeft.overflow.adjustX,
+    ).toBe(0);
   });
 
   it('if loading, arrow should show loading icon', () => {


### PR DESCRIPTION
ref:
* https://github.com/ant-design/ant-design/issues/33273
* https://github.com/react-component/select/pull/687
* https://github.com/C-Hess/select/commit/71e978917170c1b765fd43a36b44f87165cd09fe

发现是个远古 BUG，`adjustX` 为 0 希望如果超出就自动切换。但是在 [`dom-align`](https://github.com/yiminghe/dom-align/blob/7548785a1b36b4813fa49b58c36bf419e8434c91/src/align/align.js#L110) 直接根据 `adjustX` 判断是否需要转向，因而 0 就被跳过了。绕了很远，直接 `adjustX` 默认 `1` 就能转了。