### PR TITLE
fix: Pressing up with all options disabled underflowing

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -72,7 +72,8 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, OptionListP
     const len = memoFlattenOptions.length;
 
     for (let i = 0; i < len; i += 1) {
-      const current = (index + i * offset + len) % len;
+      // Use `len * 2` because if all the options are disabled `index + i * offset + len` can be < 0 (but > -len)
+      const current = (index + i * offset + len * 2) % len;
 
       const { group, data } = memoFlattenOptions[current];
       if (!group && !data.disabled) {


### PR DESCRIPTION
Previously if you had a select with all options disabled, pressing up arrow would make `current` < 0 so `memoFlattenOptions[current]` would be undefined. Multiplying `len` by 2 is an easy way to make sure it wraps around gracefully.