### PR TITLE
feat: add alternative label

### DIFF
--- a/docs/demo/alternativeLabel.md
+++ b/docs/demo/alternativeLabel.md
@@ -1,0 +1,2 @@
+## alternativeLabel
+<code src="../examples/alternativeLabel.tsx">

--- a/docs/examples/alternativeLabel.tsx
+++ b/docs/examples/alternativeLabel.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Select from 'rc-select';
+import '../../assets/index.less';
+
+const data: { value: number; label: string }[] = [];
+for (let i = 0; i < 10; i += 1) {
+  data.push({
+    value: i,
+    label: `label ${i}`,
+  });
+}
+
+const singleDefaultValue = 'x2';
+
+const multipleDefaultValue = [{ label: 'label x1', value: 'x1' }, 'x2'];
+
+function Test() {
+  return (
+    <div>
+      <h2>Select alternativeLabel</h2>
+      <Select
+        style={{ width: 500 }}
+        allowClear
+        options={data}
+        alternativeLabel={<span style={{ color: 'red' }}>error option</span>}
+        defaultValue={singleDefaultValue}
+      />
+      <br />
+      <Select
+        style={{ width: 500 }}
+        mode="multiple"
+        allowClear
+        options={data}
+        alternativeLabel={<span style={{ color: 'red' }}>error option</span>}
+        defaultValue={multipleDefaultValue}
+      />
+    </div>
+  );
+}
+
+export default Test;

--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -52,6 +52,7 @@ export type CustomTagProps = {
   label: React.ReactNode;
   value: any;
   disabled: boolean;
+  isAlternative: boolean;
   onClose: (event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   closable: boolean;
 };
@@ -61,6 +62,7 @@ export interface DisplayValueType {
   value?: RawValueType;
   label?: React.ReactNode;
   disabled?: boolean;
+  isAlternative?: boolean;
 }
 
 export interface BaseSelectRef {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -140,6 +140,7 @@ export interface SelectProps<ValueType = any, OptionType extends BaseOptionType 
   labelInValue?: boolean;
   value?: ValueType | null;
   defaultValue?: ValueType | null;
+  alternativeLabel?: React.ReactNode;
   onChange?: (value: ValueType, option: OptionType | OptionType[]) => void;
 }
 
@@ -155,6 +156,7 @@ const Select = React.forwardRef(
       prefixCls = 'rc-select',
       backfill,
       fieldNames,
+      alternativeLabel,
 
       // Search
       inputValue,
@@ -235,6 +237,8 @@ const Select = React.forwardRef(
           let rawKey: React.Key;
           let rawDisabled: boolean | undefined;
 
+          let isAlternative: boolean = false;
+
           // Fill label & value
           if (isRawValue(val)) {
             rawValue = val;
@@ -260,16 +264,21 @@ const Select = React.forwardRef(
               }
             }
           }
+          if (rawLabel === undefined && alternativeLabel) {
+            rawLabel = alternativeLabel;
+            isAlternative = true;
+          }
 
           return {
             label: rawLabel,
             value: rawValue,
             key: rawKey,
             disabled: rawDisabled,
+            isAlternative,
           };
         });
       },
-      [mergedFieldNames, optionLabelProp, valueOptions],
+      [mergedFieldNames, optionLabelProp, valueOptions, alternativeLabel],
     );
 
     // =========================== Values ===========================
@@ -312,10 +321,9 @@ const Select = React.forwardRef(
     }, [mode, mergedValues]);
 
     /** Convert `displayValues` to raw value type set */
-    const rawValues = React.useMemo(
-      () => new Set(mergedValues.map((val) => val.value)),
-      [mergedValues],
-    );
+    const rawValues = React.useMemo(() => new Set(mergedValues.map((val) => val.value)), [
+      mergedValues,
+    ]);
 
     React.useEffect(() => {
       if (mode === 'combobox') {
@@ -514,7 +522,9 @@ const Select = React.forwardRef(
         const formatted = (searchText || '').trim();
         // prevent empty tags from appearing when you click the Enter button
         if (formatted) {
-          const newRawValues = Array.from(new Set<RawValueType>([...rawValues, formatted]));
+          const newRawValues = Array.from(
+            new Set<RawValueType>([...rawValues, formatted]),
+          );
           triggerChange(newRawValues);
           triggerSelect(formatted, true);
           setSearchValue('');
@@ -544,7 +554,9 @@ const Select = React.forwardRef(
           .filter((val) => val !== undefined);
       }
 
-      const newRawValues = Array.from(new Set<RawValueType>([...rawValues, ...patchValues]));
+      const newRawValues = Array.from(
+        new Set<RawValueType>([...rawValues, ...patchValues]),
+      );
       triggerChange(newRawValues);
       newRawValues.forEach((newRawValue) => {
         triggerSelect(newRawValue, true);
@@ -626,9 +638,9 @@ if (process.env.NODE_ENV !== 'production') {
   Select.displayName = 'Select';
 }
 
-const TypedSelect = Select as unknown as (<
+const TypedSelect = (Select as unknown) as (<
   ValueType = any,
-  OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
+  OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType
 >(
   props: React.PropsWithChildren<SelectProps<ValueType, OptionType>> & {
     ref?: React.Ref<BaseSelectRef>;

--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -88,6 +88,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     title: React.ReactNode,
     content: React.ReactNode,
     itemDisabled: boolean,
+    isAlternative: boolean,
     closable?: boolean,
     onClose?: React.MouseEventHandler,
   ) {
@@ -95,6 +96,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
       <span
         className={classNames(`${selectionPrefixCls}-item`, {
           [`${selectionPrefixCls}-item-disabled`]: itemDisabled,
+          [`${selectionPrefixCls}-item-alternative`]: isAlternative,
         })}
         title={
           typeof title === 'string' || typeof title === 'number' ? title.toString() : undefined
@@ -119,6 +121,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     value: RawValueType,
     content: React.ReactNode,
     itemDisabled: boolean,
+    isAlternative: boolean,
     closable: boolean,
     onClose: React.MouseEventHandler,
   ) {
@@ -133,6 +136,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
           label: content,
           value,
           disabled: itemDisabled,
+          isAlternative,
           closable,
           onClose,
         })}
@@ -141,7 +145,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
   }
 
   function renderItem(valueItem: DisplayValueType) {
-    const { disabled: itemDisabled, label, value } = valueItem;
+    const { disabled: itemDisabled, label, value, isAlternative } = valueItem;
     const closable = !disabled && !itemDisabled;
 
     let displayLabel: React.ReactNode = label;
@@ -162,8 +166,8 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     };
 
     return typeof tagRender === 'function'
-      ? customizeRenderSelector(value, displayLabel, itemDisabled, closable, onClose)
-      : defaultRenderSelector(label, displayLabel, itemDisabled, closable, onClose);
+      ? customizeRenderSelector(value, displayLabel, itemDisabled, isAlternative, closable, onClose)
+      : defaultRenderSelector(label, displayLabel, itemDisabled, isAlternative, closable, onClose);
   }
 
   function renderRest(omittedValues: DisplayValueType[]) {
@@ -172,7 +176,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
         ? maxTagPlaceholder(omittedValues)
         : maxTagPlaceholder;
 
-    return defaultRenderSelector(content, content, false);
+    return defaultRenderSelector(content, content, false, false);
   }
 
   // >>> Input Node

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1808,4 +1808,30 @@ describe('Select.Basic', () => {
         .visibility,
     ).toBe('hidden');
   });
+
+  describe('alternative label', () => {
+    it('when single select alternative label', () => {
+      const wrapper = mount(
+        <Select
+          options={[{ value: 'yyy', label: 'test' }]}
+          alternativeLabel={<span className="alternative">error option</span>}
+          defaultValue={'xxx'}
+        />,
+      );
+      expect(wrapper.find('.alternative').length).toBeTruthy();
+    });
+
+    it('when multiple select alternative label', () => {
+      const wrapper = mount(
+        <Select
+          options={[{ value: 'yyy', label: 'test' }]}
+          alternativeLabel={<span className="alternative">error option</span>}
+          mode={'multiple'}
+          defaultValue={['xxx']}
+        />,
+      );
+      expect(wrapper.find('.rc-select-selection-item-alternative').length).toBeTruthy();
+      expect(wrapper.find('.alternative').length).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
增加一个备用的 label 渲染
在 存在表单还原场景
已选择中项有后端返回 key 
但是对应选项已经被删除了
导致查找不到对应选项
希望能通过底层提供一个备用 label 来处理
避免上层再次处理 value