### PR TITLE
fix: type definition on onSelect and onDeselect generic

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -91,9 +91,7 @@ export interface DefaultOptionType extends BaseOptionType {
   children?: Omit<DefaultOptionType, 'children'>[];
 }
 
-export type SelectHandler<ValueType = any, OptionType extends BaseOptionType = DefaultOptionType> =
-  | ((value: RawValueType | LabelInValueType, option: OptionType) => void)
-  | ((value: ValueType, option: OptionType) => void);
+export type SelectHandler<ValueType, OptionType> = (value: ValueType, option: OptionType) => void;
 
 type ArrayElementType<T> = T extends (infer E)[] ? E : T;
 


### PR DESCRIPTION
## relative link
https://github.com/ant-design/ant-design/issues/34201

背景：onSelect 和 onDeselect 类型定义不能正确映射泛型
复现链接：https://codesandbox.io/s/rc-select-onselect-type-error-7d5s2d?file=/src/App.tsx

根源在于 SelectHandler 类型定义使用了 Union Types
```
export type SelectHandler<ValueType = any, OptionType extends BaseOptionType = DefaultOptionType> =
  | ((value: RawValueType | LabelInValueType, option: OptionType) => void)
  | ((value: ValueType, option: OptionType) => void);
```
应改为
```
export type SelectHandler<ValueType, OptionType> =
  (value: ValueType, option: OptionType) => void;
```
这里移除了 Union Types ，同时移除了泛型默认值，因为 SelectProps 类型定义中已经定义了默认值
