### PR TITLE
feat: support custom label render

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ export default () => (
 | allowClear | whether allowClear | bool | false |
 | tags | when tagging is enabled the user can select from pre-existing options or create a new tag by picking the first choice, which is what the user has typed into the search box so far. | bool | false |
 | tagRender | render custom tags. | (props: CustomTagProps) => ReactNode | - |
+| labelRender | render custom label. | (props: DisplayValueType) => ReactNode | - |
 | maxTagTextLength | max tag text length to show | number | - |
 | maxTagCount | max tag count to show | number | - |
 | maxTagPlaceholder | placeholder for omitted values | ReactNode/function(omittedValues) | - |

--- a/docs/examples/single.tsx
+++ b/docs/examples/single.tsx
@@ -41,6 +41,14 @@ class Test extends React.Component {
     console.log('Search:', val);
   };
 
+  labelRender = (props) => {
+    const { label, value } = props;
+
+    return (
+      <span>label:({label}) / value:({value})</span>
+    );
+  };
+
   render() {
     const { value, destroy } = this.state;
     if (destroy) {
@@ -77,6 +85,7 @@ class Test extends React.Component {
             onPopupScroll={() => {
               console.log('Scroll!');
             }}
+            labelRender={this.labelRender}
           >
             <Option value={null}>不选择</Option>
             <Option value="01" text="jack" title="jack">

--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -125,6 +125,7 @@ export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttri
   style?: React.CSSProperties;
   showSearch?: boolean;
   tagRender?: (props: CustomTagProps) => React.ReactElement;
+  labelRender?: (props: DisplayValueType) => React.ReactNode;
   direction?: 'ltr' | 'rtl';
 
   // MISC
@@ -209,6 +210,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
     className,
     showSearch,
     tagRender,
+    labelRender,
     direction,
     omitDomProps,
 
@@ -761,6 +763,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
           mode={mode}
           activeDescendantId={activeDescendantId}
           tagRender={tagRender}
+          labelRender={labelRender}
           values={displayValues}
           open={mergedOpen}
           onToggleOpen={onToggleOpen}

--- a/src/Selector/SingleSelector.tsx
+++ b/src/Selector/SingleSelector.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 import Input from './Input';
 import type { InnerSelectorProps } from '.';
+import type { DisplayValueType } from '../BaseSelect';
 
 interface SelectorProps extends InnerSelectorProps {
   inputElement: React.ReactElement;
   activeValue: string;
+  labelRender?: (props: DisplayValueType) => React.ReactNode;
 }
 
 const SingleSelector: React.FC<SelectorProps> = (props) => {
@@ -28,6 +30,7 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
     searchValue,
     activeValue,
     maxLength,
+    labelRender,
 
     onInputKeyDown,
     onInputMouseDown,
@@ -61,6 +64,10 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
     item && (typeof item.label === 'string' || typeof item.label === 'number')
       ? item.label.toString()
       : undefined;
+
+  const renderSelectionItem = () => {
+    return typeof labelRender === 'function' ? labelRender(item) : item.label;
+  };
 
   const renderPlaceholder = () => {
     if (item) {
@@ -107,7 +114,7 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
       {/* Display value */}
       {!combobox && item && !hasTextInput && (
         <span className={`${prefixCls}-selection-item`} title={title}>
-          {item.label}
+          {renderSelectionItem()}
         </span>
       )}
 

--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -74,6 +74,7 @@ export interface SelectorProps {
   maxTagTextLength?: number;
   maxTagPlaceholder?: React.ReactNode | ((omittedValues: DisplayValueType[]) => React.ReactNode);
   tagRender?: (props: CustomTagProps) => React.ReactElement;
+  labelRender?: (props: DisplayValueType) => React.ReactNode;
 
   /** Check if `tokenSeparators` contains `\n` or `\r\n` */
   tokenWithEnter?: boolean;

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1852,4 +1852,17 @@ describe('Select.Basic', () => {
     expect(wrapper.find('div.rc-select-item').prop('data-test')).toEqual('good');
     expect(wrapper.find('div.rc-select-item').prop('aria-label')).toEqual('well');
   });
+
+  it('labelRender', () => {
+    const onLabelRender = jest.fn();
+    const labelRender = (props: any) => {
+      const { label, value } = props;
+      onLabelRender();
+      return `${label}-${value}`;
+    };
+    const wrapper = mount(<Select value="a" labelRender={labelRender} />);
+
+    expect(onLabelRender).toHaveBeenCalled();
+    expect(findSelection(wrapper).text()).toEqual('a-a');
+  });
 });


### PR DESCRIPTION
单选时，允许自定义渲染 label 。  

使用场景：  
当初始化时，若 value 不存在于待选列表中。之前的默认行为，是将 value 作为 label 显示。  
但大部分场景，会将 id 作为 value ，将 name 作为 label 。此时默认行为就不够友好了。  
现提供 labelRender 配置，允许用户自定义此场景下的显示策略。  

fix:  
https://github.com/ant-design/ant-design/issues/27678  
https://github.com/ant-design/ant-design/issues/28138  
