### PR TITLE
fix: Group title warning

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -292,7 +292,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, OptionListP
 
           // Group
           if (group) {
-            const groupTitle = data.title ?? (isTitleType(label) && label);
+            const groupTitle = data.title ?? (isTitleType(label) ? label.toString() : undefined);
 
             return (
               <div

--- a/tests/Group.test.tsx
+++ b/tests/Group.test.tsx
@@ -55,5 +55,15 @@ describe('Select.Group', () => {
 
       expect(wrapper.find('.rc-select-item-group').prop('title')).toEqual('bamboo');
     });
+
+    it('title as undefined', () => {
+      const wrapper = mount(
+        <Select open>
+          <OptGroup label={<span>zombiej</span>} />
+        </Select>,
+      );
+
+      expect(wrapper.find('.rc-select-item-group').prop('title')).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Previously the Group element showed some warnings regarding the title not being of type string for non-title type label values. This PR adds additional safeguards to avoid that.

fix https://github.com/ant-design/ant-design/issues/36005