### PR TITLE
Add prettier latest version and option null value warning.

### DIFF
--- a/docs/examples/controlled.tsx
+++ b/docs/examples/controlled.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import Select, { OptGroup, Option } from 'rc-select';
+import Select, { Option } from 'rc-select';
 import React from 'react';
 import '../../assets/index.less';
 
@@ -70,11 +70,6 @@ class Controlled extends React.Component<{}, ControlledState> {
             onChange={this.onChange}
             onDropdownVisibleChange={this.onDropdownVisibleChange}
           >
-            <OptGroup>
-              <Option value={111}>111</Option>
-              <Option value={null}>null</Option>
-            </OptGroup>
-
             <Option value="01" text="jack" title="jack">
               <b
                 style={{

--- a/docs/examples/controlled.tsx
+++ b/docs/examples/controlled.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
+import Select, { OptGroup, Option } from 'rc-select';
 import React from 'react';
-import Select, { Option } from 'rc-select';
 import '../../assets/index.less';
 
 interface ControlledState {
@@ -16,7 +16,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     open: true,
   };
 
-  onChange = e => {
+  onChange = (e) => {
     let value;
     if (e && e.target) {
       ({ value } = e.target);
@@ -35,7 +35,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     });
   };
 
-  onBlur = v => {
+  onBlur = (v) => {
     console.log('onBlur', v);
   };
 
@@ -43,7 +43,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     console.log('onFocus');
   };
 
-  onDropdownVisibleChange = open => {
+  onDropdownVisibleChange = (open) => {
     this.setState({ open });
   };
 
@@ -70,6 +70,11 @@ class Controlled extends React.Component<{}, ControlledState> {
             onChange={this.onChange}
             onDropdownVisibleChange={this.onDropdownVisibleChange}
           >
+            <OptGroup>
+              <Option value={111}>111</Option>
+              <Option value={null}>null</Option>
+            </OptGroup>
+
             <Option value="01" text="jack" title="jack">
               <b
                 style={{
@@ -88,7 +93,7 @@ class Controlled extends React.Component<{}, ControlledState> {
             <Option value="31" text="yiminghe">
               yiminghe
             </Option>
-            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => (
+            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => (
               <Option key={i} value={i} text={String(i)}>
                 {i}-text
               </Option>

--- a/docs/examples/controlled.tsx
+++ b/docs/examples/controlled.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import Select, { Option } from 'rc-select';
 import React from 'react';
+import Select, { Option } from 'rc-select';
 import '../../assets/index.less';
 
 interface ControlledState {
@@ -16,7 +16,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     open: true,
   };
 
-  onChange = (e) => {
+  onChange = e => {
     let value;
     if (e && e.target) {
       ({ value } = e.target);
@@ -35,7 +35,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     });
   };
 
-  onBlur = (v) => {
+  onBlur = v => {
     console.log('onBlur', v);
   };
 
@@ -43,7 +43,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     console.log('onFocus');
   };
 
-  onDropdownVisibleChange = (open) => {
+  onDropdownVisibleChange = open => {
     this.setState({ open });
   };
 
@@ -88,7 +88,7 @@ class Controlled extends React.Component<{}, ControlledState> {
             <Option value="31" text="yiminghe">
               yiminghe
             </Option>
-            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((i) => (
+            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => (
               <Option key={i} value={i} text={String(i)}>
                 {i}-text
               </Option>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "father": "^2.13.2",
     "jsonp": "^0.2.1",
     "np": "^7.5.0",
+    "prettier": "^2.7.1",
     "rc-dialog": "^8.1.1",
     "typescript": "^4.2.3"
   }

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -600,7 +600,7 @@ const Select = React.forwardRef(
     // ========================== Warning ===========================
     if (process.env.NODE_ENV !== 'production') {
       warningProps(props);
-      warningNullOptions(mergedOptions);
+      warningNullOptions(mergedOptions, mergedFieldNames);
     }
 
     // ==============================================================

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -29,24 +29,29 @@
  * - `combobox` mode not support `optionLabelProp`
  */
 
-import * as React from 'react';
-import warning from 'rc-util/lib/warning';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
+import warning from 'rc-util/lib/warning';
+import * as React from 'react';
+import type {
+  BaseSelectProps,
+  BaseSelectPropsWithoutPrivate,
+  BaseSelectRef,
+  DisplayValueType,
+  RenderNode,
+} from './BaseSelect';
 import BaseSelect, { isMultiple } from './BaseSelect';
-import type { DisplayValueType, RenderNode } from './BaseSelect';
-import OptionList from './OptionList';
-import Option from './Option';
-import OptGroup from './OptGroup';
-import type { BaseSelectRef, BaseSelectPropsWithoutPrivate, BaseSelectProps } from './BaseSelect';
-import useOptions from './hooks/useOptions';
-import SelectContext from './SelectContext';
-import useId from './hooks/useId';
-import useRefFunc from './hooks/useRefFunc';
-import { fillFieldNames, flattenOptions, injectPropsWithOption } from './utils/valueUtil';
-import warningProps from './utils/warningPropsUtil';
-import { toArray } from './utils/commonUtil';
-import useFilterOptions from './hooks/useFilterOptions';
 import useCache from './hooks/useCache';
+import useFilterOptions from './hooks/useFilterOptions';
+import useId from './hooks/useId';
+import useOptions from './hooks/useOptions';
+import useRefFunc from './hooks/useRefFunc';
+import OptGroup from './OptGroup';
+import Option from './Option';
+import OptionList from './OptionList';
+import SelectContext from './SelectContext';
+import { toArray } from './utils/commonUtil';
+import { fillFieldNames, flattenOptions, injectPropsWithOption } from './utils/valueUtil';
+import warningProps, { warningNullOptions } from './utils/warningPropsUtil';
 
 const OMIT_DOM_PROPS = ['inputValue'];
 
@@ -229,18 +234,6 @@ const Select = React.forwardRef(
       optionLabelProp,
     );
     const { valueOptions, labelOptions, options: mergedOptions } = parsedOptions;
-
-    // value in Select option can not be null
-    if (process.env.NODE_ENV !== 'production') {
-      mergedOptions.forEach((item: DefaultOptionType, index: number) => {
-        if (item.value === null) {
-          warning(
-            false,
-            `\`value\` in Select options can not be \`null\`, please use \`string | number\` instead. Please check the index \`${index}\` of options.`,
-          );
-        }
-      });
-    }
 
     // ========================= Wrap Value =========================
     const convert2LabelValues = React.useCallback(
@@ -607,6 +600,7 @@ const Select = React.forwardRef(
     // ========================== Warning ===========================
     if (process.env.NODE_ENV !== 'production') {
       warningProps(props);
+      warningNullOptions(mergedOptions);
     }
 
     // ==============================================================

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -230,6 +230,18 @@ const Select = React.forwardRef(
     );
     const { valueOptions, labelOptions, options: mergedOptions } = parsedOptions;
 
+    console.log('mergedOptions', mergedOptions);
+
+    // value in Select option can not be null
+    mergedOptions.forEach((item: DefaultOptionType, index: number) => {
+      if (item.value === null) {
+        warning(
+          false,
+          `\`value\` in Select options can not be \`null\`, please use \`string | number\` instead. Please check the index \`${index}\` of options.`,
+        );
+      }
+    });
+
     // ========================= Wrap Value =========================
     const convert2LabelValues = React.useCallback(
       (draftValues: DraftValueType) => {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -230,8 +230,6 @@ const Select = React.forwardRef(
     );
     const { valueOptions, labelOptions, options: mergedOptions } = parsedOptions;
 
-    console.log('mergedOptions', mergedOptions);
-
     // value in Select option can not be null
     mergedOptions.forEach((item: DefaultOptionType, index: number) => {
       if (item.value === null) {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -231,14 +231,16 @@ const Select = React.forwardRef(
     const { valueOptions, labelOptions, options: mergedOptions } = parsedOptions;
 
     // value in Select option can not be null
-    mergedOptions.forEach((item: DefaultOptionType, index: number) => {
-      if (item.value === null) {
-        warning(
-          false,
-          `\`value\` in Select options can not be \`null\`, please use \`string | number\` instead. Please check the index \`${index}\` of options.`,
-        );
-      }
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      mergedOptions.forEach((item: DefaultOptionType, index: number) => {
+        if (item.value === null) {
+          warning(
+            false,
+            `\`value\` in Select options can not be \`null\`, please use \`string | number\` instead. Please check the index \`${index}\` of options.`,
+          );
+        }
+      });
+    }
 
     // ========================= Wrap Value =========================
     const convert2LabelValues = React.useCallback(

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -97,10 +97,28 @@ function warningProps(props: SelectProps) {
     );
   }
 
+  // value in select option can not be null
+  const nullValueWarning = () =>
+    warning(
+      false,
+      '`value` in select option can not be null, please use `string | number` instead.',
+    );
+
+  if (options) {
+    for (let i = 0; i < options.length; i++) {
+      if (options[i]?.value === null) {
+        nullValueWarning();
+        break;
+      }
+    }
+  }
+
   // Syntactic sugar should use correct children type
   if (children) {
     let invalidateChildType = null;
-    toNodeArray(children).some((node: React.ReactNode) => {
+    const childrenArray = toNodeArray(children);
+
+    childrenArray.some((node: React.ReactNode) => {
       if (!React.isValidElement(node) || !node.type) {
         return false;
       }
@@ -147,6 +165,13 @@ function warningProps(props: SelectProps) {
       inputValue === undefined,
       '`inputValue` is deprecated, please use `searchValue` instead.',
     );
+
+    for (let i = 0; i < childrenArray.length; i++) {
+      if (childrenArray[i]?.props?.value === null) {
+        nullValueWarning();
+        break;
+      }
+    }
   }
 }
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -159,34 +159,28 @@ function warningProps(props: SelectProps) {
 
 // value in Select option should not be null
 // note: OptGroup has options too
-export function warningNullOptions(
-  mergedOptions: DefaultOptionType[],
-  mergedFieldNames: FieldNames,
-) {
-  if (mergedOptions) {
-    let isRecursive = true;
-    const recursiveOptions = (options: DefaultOptionType[]): boolean => {
-      for (let i = 0; i < options.length; i++) {
-        const option = options[i];
+export function warningNullOptions(options: DefaultOptionType[], fieldNames: FieldNames) {
+  if (options) {
+    const recursiveOptions = (optionsList: DefaultOptionType[], inGroup: boolean = false) => {
+      for (let i = 0; i < optionsList.length; i++) {
+        const option = optionsList[i];
 
-        if (option[mergedFieldNames?.value] === null) {
+        if (option[fieldNames?.value] === null) {
           warning(false, '`value` in Select options should not be `null`.');
           return true;
         }
 
-        if (option[mergedFieldNames?.options] && isRecursive) {
-          isRecursive = false;
-          if (recursiveOptions(option[mergedFieldNames?.options])) {
-            return true;
-          }
-          isRecursive = true;
+        if (
+          !inGroup &&
+          Array.isArray(option[fieldNames?.options]) &&
+          recursiveOptions(option[fieldNames?.options], true)
+        ) {
+          break;
         }
       }
-
-      return false;
     };
 
-    recursiveOptions(mergedOptions);
+    recursiveOptions(options);
   }
 }
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -97,28 +97,10 @@ function warningProps(props: SelectProps) {
     );
   }
 
-  // value in select option can not be null
-  const nullValueWarning = () =>
-    warning(
-      false,
-      '`value` in select option can not be null, please use `string | number` instead.',
-    );
-
-  if (options) {
-    for (let i = 0; i < options.length; i++) {
-      if (options[i]?.value === null) {
-        nullValueWarning();
-        break;
-      }
-    }
-  }
-
   // Syntactic sugar should use correct children type
   if (children) {
     let invalidateChildType = null;
-    const childrenArray = toNodeArray(children);
-
-    childrenArray.some((node: React.ReactNode) => {
+    toNodeArray(children).some((node: React.ReactNode) => {
       if (!React.isValidElement(node) || !node.type) {
         return false;
       }
@@ -165,13 +147,6 @@ function warningProps(props: SelectProps) {
       inputValue === undefined,
       '`inputValue` is deprecated, please use `searchValue` instead.',
     );
-
-    for (let i = 0; i < childrenArray.length; i++) {
-      if (childrenArray[i]?.props?.value === null) {
-        nullValueWarning();
-        break;
-      }
-    }
   }
 }
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -156,14 +156,30 @@ function warningProps(props: SelectProps) {
   }
 }
 
-// value in Select option can not be null
-export function warningNullOptions(options: DefaultOptionType[]) {
-  options.forEach((option: DefaultOptionType, index: number) => {
-    warning(
-      option?.value !== null,
-      `\`value\` in Select options can not be \`null\`, please use \`string | number\` instead. Please check the index \`${index}\` of options.`,
-    );
-  });
+// value in Select option should not be null
+// note: OptGroup has options too
+export function warningNullOptions(mergedOptions: DefaultOptionType[]) {
+  if (mergedOptions) {
+    for (let index = 0; index < mergedOptions.length; index++) {
+      const option = mergedOptions[index];
+
+      if (option?.value === null) {
+        warning(false, '`value` in Select options should not be `null`.');
+        break;
+      }
+
+      if (option?.options) {
+        const optOptions = option.options;
+
+        for (let subIndex = 0; subIndex < optOptions.length; subIndex++) {
+          if (optOptions[subIndex]?.value === null) {
+            warning(false, '`value` in Select OptGroup options should not be `null`.');
+            break;
+          }
+        }
+      }
+    }
+  }
 }
 
 export default warningProps;

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -160,25 +160,24 @@ function warningProps(props: SelectProps) {
 // note: OptGroup has options too
 export function warningNullOptions(mergedOptions: DefaultOptionType[]) {
   if (mergedOptions) {
-    for (let index = 0; index < mergedOptions.length; index++) {
-      const option = mergedOptions[index];
+    const recursiveOptions = (options: DefaultOptionType[]): boolean => {
+      for (let i = 0; i < options.length; i++) {
+        const option = options[i];
 
-      if (option?.value === null) {
-        warning(false, '`value` in Select options should not be `null`.');
-        break;
-      }
+        if (option?.value === null) {
+          warning(false, '`value` in Select options should not be `null`.');
+          return true;
+        }
 
-      if (option?.options) {
-        const optOptions = option.options;
-
-        for (let subIndex = 0; subIndex < optOptions.length; subIndex++) {
-          if (optOptions[subIndex]?.value === null) {
-            warning(false, '`value` in Select OptGroup options should not be `null`.');
-            break;
-          }
+        if (option?.options && recursiveOptions(option.options)) {
+          return true;
         }
       }
-    }
+
+      return false;
+    };
+
+    recursiveOptions(mergedOptions);
   }
 }
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -1,10 +1,16 @@
-import * as React from 'react';
-import warning, { noteOnce } from 'rc-util/lib/warning';
 import toNodeArray from 'rc-util/lib/Children/toArray';
-import { convertChildrenToData } from './legacyUtil';
-import { toArray } from './commonUtil';
-import type { RawValueType, LabelInValueType, BaseOptionType, SelectProps } from '../Select';
+import warning, { noteOnce } from 'rc-util/lib/warning';
+import * as React from 'react';
 import { isMultiple } from '../BaseSelect';
+import type {
+  BaseOptionType,
+  DefaultOptionType,
+  LabelInValueType,
+  RawValueType,
+  SelectProps,
+} from '../Select';
+import { toArray } from './commonUtil';
+import { convertChildrenToData } from './legacyUtil';
 
 function warningProps(props: SelectProps) {
   const {
@@ -148,6 +154,16 @@ function warningProps(props: SelectProps) {
       '`inputValue` is deprecated, please use `searchValue` instead.',
     );
   }
+}
+
+// value in Select option can not be null
+export function warningNullOptions(options: DefaultOptionType[]) {
+  options.forEach((option: DefaultOptionType, index: number) => {
+    warning(
+      option?.value !== null,
+      `\`value\` in Select options can not be \`null\`, please use \`string | number\` instead. Please check the index \`${index}\` of options.`,
+    );
+  });
 }
 
 export default warningProps;

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -5,6 +5,7 @@ import { isMultiple } from '../BaseSelect';
 import type {
   BaseOptionType,
   DefaultOptionType,
+  FieldNames,
   LabelInValueType,
   RawValueType,
   SelectProps,
@@ -158,19 +159,27 @@ function warningProps(props: SelectProps) {
 
 // value in Select option should not be null
 // note: OptGroup has options too
-export function warningNullOptions(mergedOptions: DefaultOptionType[]) {
+export function warningNullOptions(
+  mergedOptions: DefaultOptionType[],
+  mergedFieldNames: FieldNames,
+) {
   if (mergedOptions) {
+    let isRecursive = true;
     const recursiveOptions = (options: DefaultOptionType[]): boolean => {
       for (let i = 0; i < options.length; i++) {
         const option = options[i];
 
-        if (option?.value === null) {
+        if (option[mergedFieldNames?.value] === null) {
           warning(false, '`value` in Select options should not be `null`.');
           return true;
         }
 
-        if (option?.options && recursiveOptions(option.options)) {
-          return true;
+        if (option[mergedFieldNames?.options] && isRecursive) {
+          isRecursive = false;
+          if (recursiveOptions(option[mergedFieldNames?.options])) {
+            return true;
+          }
+          isRecursive = true;
         }
       }
 

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1702,6 +1702,35 @@ describe('Select.Basic', () => {
 
       expect(errorSpy).toHaveBeenCalledWith(warningMessage);
     });
+
+    it('`null` is a value in fieldNames should throw a warning', () => {
+      mount(
+        <Select
+          fieldNames={{
+            label: 'fieldLabel',
+            value: 'fieldValue',
+            options: 'fieldOptions',
+          }}
+          options={[
+            {
+              fieldLabel: 'label',
+              fieldOptions: [
+                {
+                  fieldLabel: '1',
+                  fieldValue: '1',
+                },
+                {
+                  fieldLabel: '2',
+                  fieldValue: null,
+                },
+              ],
+            },
+          ]}
+        />,
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(warningMessage);
+    });
   });
 
   describe('show placeholder', () => {

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1646,35 +1646,65 @@ describe('Select.Basic', () => {
     });
   });
 
-  it('`null` is a value and need to throw warning', () => {
-    const onChange = jest.fn();
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  describe('`null` is a value', () => {
+    let errorSpy;
 
-    const wrapper = mount(
-      <Select onChange={onChange}>
-        <Option value={1}>1</Option>
-        <Option value={null}>No</Option>
-        <Option value={0}>0</Option>
-        <Option value="">Empty</Option>
-      </Select>,
-    );
-
-    [
-      [1, '1'],
-      [null, 'No'],
-      [0, '0'],
-      ['', 'Empty'],
-    ].forEach(([value, showValue], index) => {
-      toggleOpen(wrapper);
-      selectItem(wrapper, index);
-      expect(onChange).toHaveBeenCalledWith(value, expect.anything());
-      expect(wrapper.find('.rc-select-selection-item').text()).toEqual(showValue);
+    beforeAll(() => {
+      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
     });
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: `value` in Select options can not be `null`, please use `string | number` instead. Please check the index `1` of options.',
-    );
-    errorSpy.mockRestore();
+    beforeEach(() => {
+      errorSpy.mockReset();
+      resetWarned();
+    });
+
+    afterAll(() => {
+      errorSpy.mockRestore();
+    });
+
+    it('`null` is a value and should throw a warning', () => {
+      const onChange = jest.fn();
+
+      const wrapper = mount(
+        <Select onChange={onChange}>
+          <Option value={1}>1</Option>
+          <Option value={null}>No</Option>
+          <Option value={0}>0</Option>
+          <Option value="">Empty</Option>
+        </Select>,
+      );
+
+      [
+        [1, '1'],
+        [null, 'No'],
+        [0, '0'],
+        ['', 'Empty'],
+      ].forEach(([value, showValue], index) => {
+        toggleOpen(wrapper);
+        selectItem(wrapper, index);
+        expect(onChange).toHaveBeenCalledWith(value, expect.anything());
+        expect(wrapper.find('.rc-select-selection-item').text()).toEqual(showValue);
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Warning: `value` in Select options should not be `null`.',
+      );
+    });
+
+    it('`null` is a value in OptGroup should throw a warning', () => {
+      mount(
+        <Select>
+          <OptGroup>
+            <Option value="1">1</Option>
+            <Option value={null}>null</Option>
+          </OptGroup>
+        </Select>,
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Warning: `value` in Select OptGroup options should not be `null`.',
+      );
+    });
   });
 
   describe('show placeholder', () => {

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1648,6 +1648,7 @@ describe('Select.Basic', () => {
 
   describe('`null` is a value', () => {
     let errorSpy;
+    const warningMessage = 'Warning: `value` in Select options should not be `null`.';
 
     beforeAll(() => {
       errorSpy = jest.spyOn(console, 'error').mockImplementation(() => null);
@@ -1686,9 +1687,7 @@ describe('Select.Basic', () => {
         expect(wrapper.find('.rc-select-selection-item').text()).toEqual(showValue);
       });
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Warning: `value` in Select options should not be `null`.',
-      );
+      expect(errorSpy).toHaveBeenCalledWith(warningMessage);
     });
 
     it('`null` is a value in OptGroup should throw a warning', () => {
@@ -1701,9 +1700,7 @@ describe('Select.Basic', () => {
         </Select>,
       );
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Warning: `value` in Select OptGroup options should not be `null`.',
-      );
+      expect(errorSpy).toHaveBeenCalledWith(warningMessage);
     });
   });
 

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1,27 +1,27 @@
 import { mount, render } from 'enzyme';
 import KeyCode from 'rc-util/lib/KeyCode';
+import { spyElementPrototype } from 'rc-util/lib/test/domHook';
+import { resetWarned } from 'rc-util/lib/warning';
+import VirtualList from 'rc-virtual-list';
+import type { ScrollConfig } from 'rc-virtual-list/lib/List';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { resetWarned } from 'rc-util/lib/warning';
-import type { ScrollConfig } from 'rc-virtual-list/lib/List';
-import { spyElementPrototype } from 'rc-util/lib/test/domHook';
-import VirtualList from 'rc-virtual-list';
 import type { SelectProps } from '../src';
 import Select, { OptGroup, Option, useBaseProps } from '../src';
-import focusTest from './shared/focusTest';
-import blurTest from './shared/blurTest';
-import keyDownTest from './shared/keyDownTest';
-import inputFilterTest from './shared/inputFilterTest';
-import openControlledTest from './shared/openControlledTest';
+import type { BaseSelectRef } from '../src/BaseSelect';
 import allowClearTest from './shared/allowClearTest';
+import blurTest from './shared/blurTest';
+import focusTest from './shared/focusTest';
+import inputFilterTest from './shared/inputFilterTest';
+import keyDownTest from './shared/keyDownTest';
+import openControlledTest from './shared/openControlledTest';
 import {
   expectOpen,
-  toggleOpen,
-  selectItem,
   findSelection,
   injectRunAllTimers,
+  selectItem,
+  toggleOpen,
 } from './utils/common';
-import type { BaseSelectRef } from '../src/BaseSelect';
 
 describe('Select.Basic', () => {
   injectRunAllTimers(jest);
@@ -602,7 +602,7 @@ describe('Select.Basic', () => {
         </Select>,
       );
 
-      const inputSpy = jest.spyOn(wrapper2.find('input').instance(), 'focus');
+      const inputSpy = jest.spyOn(wrapper2.find('input').instance(), 'focus' as any);
 
       wrapper2.find('.rc-select-selection-placeholder').simulate('mousedown');
       wrapper2.find('.rc-select-selection-placeholder').simulate('click');
@@ -807,9 +807,9 @@ describe('Select.Basic', () => {
       }
     }
     const wrapper = mount(<Controlled />);
-    expect(wrapper.state().open).toBe(true);
+    expect((wrapper.state() as any).open).toBe(true);
     toggleOpen(wrapper);
-    expect(wrapper.state().open).toBe(false);
+    expect((wrapper.state() as any).open).toBe(false);
 
     selectItem(wrapper);
     expectOpen(wrapper, false);
@@ -822,7 +822,7 @@ describe('Select.Basic', () => {
       </Select>,
     );
 
-    const focusSpy = jest.spyOn(wrapper.find('input').instance(), 'focus');
+    const focusSpy = jest.spyOn(wrapper.find('input').instance(), 'focus' as any);
     wrapper.find('.rc-select-selection-placeholder').simulate('mousedown');
     wrapper.find('.rc-select-selection-placeholder').simulate('click');
     expect(focusSpy).toHaveBeenCalled();
@@ -1646,8 +1646,9 @@ describe('Select.Basic', () => {
     });
   });
 
-  it('`null` is a value', () => {
+  it('`null` is a value and need to throw warning', () => {
     const onChange = jest.fn();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const wrapper = mount(
       <Select onChange={onChange}>
@@ -1669,6 +1670,11 @@ describe('Select.Basic', () => {
       expect(onChange).toHaveBeenCalledWith(value, expect.anything());
       expect(wrapper.find('.rc-select-selection-item').text()).toEqual(showValue);
     });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: `value` in Select options can not be `null`, please use `string | number` instead. Please check the index `1` of options.',
+    );
+    errorSpy.mockRestore();
   });
 
   describe('show placeholder', () => {


### PR DESCRIPTION
Changes:

1. add prettier latest (2.x) version to devDependencies, because the current prettier version added by 'umi-utils' is 1.x, which can't deal with typescript import type syntax (prettier 1.x error: SyntaxError: '=' expected).
2. add node children & options null value warning.

---

Chinese:
1. 添加了 prettier 的最新版本（2.x）到 devDependencies，因为当前由 'umi-utils' 安装的的 prettier 版本是 1.x, 不能正确处理 typescript 的 import type 语法（prettier 1.x 会报错：SyntaxError: '=' expected）。
2. 添加了 null 作为 option value 时的告警。