### PR TITLE
fix: use optional 'forceRender' prop to pre-render the listbox

### DIFF
--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -263,6 +263,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
     dropdownAlign,
     placement,
     getPopupContainer,
+    forceRender,
 
     // Focus
     showAction = [],
@@ -745,6 +746,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
       getTriggerDOMNode={() => selectorDomRef.current}
       onPopupVisibleChange={onTriggerVisibleChange}
       onPopupMouseEnter={onPopupMouseEnter}
+      forceRender={forceRender}
     >
       {customizeRawInputElement ? (
         React.cloneElement(customizeRawInputElement, {

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -71,6 +71,8 @@ export interface SelectTriggerProps {
   onPopupVisibleChange?: (visible: boolean) => void;
 
   onPopupMouseEnter: () => void;
+
+  forceRender?: boolean;
 }
 
 const SelectTrigger: React.RefForwardingComponent<RefTriggerProps, SelectTriggerProps> = (


### PR DESCRIPTION
As it stand right now, the listbox is added to the DOM after the user interacts with the Select component. This is a problem because it will throw an error when running accessibility tests. To fix this, allow 'forceRender' prop to be passed to SelectTrigger in order for it to render the listbox before any user interaction