### PR TITLE
feat: allow rendering all options inside list box for better screen reader experience

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -58,6 +58,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, OptionListP
     virtual,
     listHeight,
     listItemHeight,
+    renderFullOptionList,
   } = React.useContext(SelectContext);
 
   const itemPrefixCls = `${prefixCls}-item`;
@@ -271,9 +272,9 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, OptionListP
   return (
     <>
       <div role="listbox" id={`${id}_list`} style={{ height: 0, width: 0, overflow: 'hidden' }}>
-        {renderItem(activeIndex - 1)}
-        {renderItem(activeIndex)}
-        {renderItem(activeIndex + 1)}
+        {renderFullOptionList
+          ? [...Array(flattenOptions.length).keys()].map((index) => renderItem(index))
+          : [activeIndex - 1, activeIndex, activeIndex + 1].map((index) => renderItem(index))}
       </div>
       <List<FlattenOptionData<BaseOptionType>>
         itemKey="key"

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -139,6 +139,7 @@ export interface SelectProps<ValueType = any, OptionType extends BaseOptionType 
   virtual?: boolean;
   listHeight?: number;
   listItemHeight?: number;
+  renderFullOptionList?: boolean;
 
   // >>> Icon
   menuItemSelectedIcon?: RenderNode;
@@ -186,6 +187,7 @@ const Select = React.forwardRef(
       virtual,
       listHeight = 200,
       listItemHeight = 20,
+      renderFullOptionList,
 
       // Value
       value,
@@ -580,6 +582,7 @@ const Select = React.forwardRef(
         listHeight,
         listItemHeight,
         childrenAsData,
+        renderFullOptionList,
       };
     }, [
       parsedOptions,
@@ -595,6 +598,7 @@ const Select = React.forwardRef(
       listHeight,
       listItemHeight,
       childrenAsData,
+      renderFullOptionList,
     ]);
 
     // ========================== Warning ===========================

--- a/src/SelectContext.ts
+++ b/src/SelectContext.ts
@@ -17,6 +17,7 @@ export interface SelectContextProps {
   listHeight?: number;
   listItemHeight?: number;
   childrenAsData?: boolean;
+  renderFullOptionList?: boolean;
 }
 
 const SelectContext = React.createContext<SelectContextProps>(null);


### PR DESCRIPTION
Currently only the active item and the adjacent ones are rendered inside [role="listbox"]. This is problematic for screen readers, because they will announce an item as "Option 2 of 3" (3 options in total, current one is second), when it might be option 5 of 10. To fix this, all the options must be present inside [role="listbox"], so that screen readers know the full length of options and the position of the current one. 

Not sure why it is implemented the way it is now, so I added the feature as an optional prop, although i think this should be the default way it works. 