### PR TITLE
fix: Bugs caused by missing animation-name

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -315,12 +315,15 @@
   }
 
   &-slide-up-enter&-slide-up-enter-active&-placement-topLeft,
-  &-slide-up-appear&-slide-up-appear-active&-placement-topLeft {
+  &-slide-up-appear&-slide-up-appear-active&-placement-topLeft,
+  &-slide-up-enter&-slide-up-enter-active&-placement-topRight,
+  &-slide-up-appear&-slide-up-appear-active&-placement-topRight {
     animation-name: rcSelectDropdownSlideDownIn;
     animation-play-state: running;
   }
 
-  &-slide-up-leave&-slide-up-leave-active&-placement-topLeft {
+  &-slide-up-leave&-slide-up-leave-active&-placement-topLeft,
+  &-slide-up-leave&-slide-up-leave-active&-placement-topRight {
     animation-name: rcSelectDropdownSlideDownOut;
     animation-play-state: running;
   }
@@ -348,6 +351,34 @@
     opacity: 0;
     transform-origin: 0% 0%;
     transform: scaleY(0);
+  }
+}
+
+@keyframes rcSelectDropdownSlideDownIn {
+  0% {
+    transform: scaleY(0);
+    transform-origin: 100% 100%;
+    opacity: 0;
+  }
+
+  100% {
+    transform: scaleY(1);
+    transform-origin: 100% 100%;
+    opacity: 1;
+  }
+}
+
+@keyframes rcSelectDropdownSlideDownOut {
+  0% {
+    transform: scaleY(1);
+    transform-origin: 100% 100%;
+    opacity: 1;
+  }
+
+  100% {
+    transform: scaleY(0);
+    transform-origin: 100% 100%;
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
When Select animation is "slide-up" and placement is topLeft or topRight, rc-motion cannot trigger animationEnd event because animation-name is missing. cause Select error.

online demo: https://stackblitz.com/edit/react-ts-tcnr1w?file=App.tsx

related issues:
* https://github.com/react-component/select/issues/631
* https://github.com/react-component/select/issues/789