### PR TITLE
fix: remove by `Backspace` on input inside dropdown menu effect remove item event

### DIFF
--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -272,7 +272,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
 
     // Rest Events
     onKeyUp,
-    onKeyDown,
+    onInputKeyDown,
     onMouseDown,
 
     // Rest Props
@@ -450,7 +450,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
   const [getClearLock, setClearLock] = useLock();
 
   // KeyDown
-  const onInternalKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event, ...rest) => {
+  const onInputInternalKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event, ...rest) => {
     const clearLock = getClearLock();
     const { which } = event;
 
@@ -501,7 +501,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
       listRef.current.onKeyDown(event, ...rest);
     }
 
-    onKeyDown?.(event, ...rest);
+    onInputKeyDown?.(event, ...rest);
   };
 
   // KeyUp
@@ -777,6 +777,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
           onSearchSubmit={onInternalSearchSubmit}
           onRemove={onSelectorRemove}
           tokenWithEnter={tokenWithEnter}
+          onInputKeyDown={onInputInternalKeyDown}
         />
       )}
     </SelectTrigger>
@@ -795,7 +796,6 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
         {...domProps}
         ref={containerRef}
         onMouseDown={onInternalMouseDown}
-        onKeyDown={onInternalKeyDown}
         onKeyUp={onInternalKeyUp}
         onFocus={onContainerFocus}
         onBlur={onContainerBlur}

--- a/tests/shared/removeSelectedTest.tsx
+++ b/tests/shared/removeSelectedTest.tsx
@@ -82,7 +82,9 @@ export default function removeSelectedTest(mode: any) {
         </Select>,
       );
 
-      wrapper.find('input').simulate('keyDown', { which: KeyCode.BACKSPACE });
+      wrapper
+        .find('input.rc-select-selection-search-input')
+        .simulate('keyDown', { which: KeyCode.BACKSPACE });
       expect(onChange).toHaveBeenCalledWith(['1'], [expect.objectContaining({ value: '1' })]);
     });
 


### PR DESCRIPTION
I have fixed the issue #834