### PR TITLE
fix: tsc --noEmit error

### DIFF
--- a/docs/examples/custom-tags.tsx
+++ b/docs/examples/custom-tags.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Select, { Option } from 'rc-select';
 import '../../assets/index.less';
-import type { CustomTagProps } from '../src/interface/generator';
+import type { CustomTagProps } from 'rc-select/src/BaseSelect';
 
 const children = [];
 for (let i = 10; i < 36; i += 1) {

--- a/docs/examples/custom-tags.tsx
+++ b/docs/examples/custom-tags.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import Select, { Option } from 'rc-select';
 import '../../assets/index.less';
-import type { CustomTagProps } from 'rc-select/src/BaseSelect';
+import type { CustomTagProps } from '@/BaseSelect';
+
 
 const children = [];
 for (let i = 10; i < 36; i += 1) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build": "dumi build",
     "compile": "father build",
     "prepublishOnly": "npm run compile && np --yolo --no-publish",
-    "lint": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
+    "lint":"npm run tsc && npm run lint:script",
+    "lint:script": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
     "test": "rc-test",
     "tsc": "tsc --noEmit",
     "now-build": "npm run build"

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -32,7 +32,7 @@ function isTitleType(content: any) {
  * Using virtual list of option display.
  * Will fallback to dom if use customize render.
  */
-const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, OptionListProps> = (
+const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (
   _,
   ref,
 ) => {

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -89,7 +89,7 @@ export function flattenOptions<OptionType extends BaseOptionType = DefaultOption
 /**
  * Inject `props` into `option` for legacy usage
  */
-export function injectPropsWithOption<T>(option: T): T {
+export function injectPropsWithOption<T extends object>(option: T): T {
   const newOption = { ...option };
   if (!('props' in newOption)) {
     Object.defineProperty(newOption, 'props', {


### PR DESCRIPTION
1. 'CustomTagProps' is removed in '../src/interface/generator';
2. '\<OptionList  ref={ref} /\>' ref:any can't distribute to ref:never