### PR TITLE
fix: SelectHandler type fix

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -97,9 +97,10 @@ export interface DefaultOptionType extends BaseOptionType {
   children?: Omit<DefaultOptionType, 'children'>[];
 }
 
-export type SelectHandler<ValueType = any, OptionType extends BaseOptionType = DefaultOptionType> =
-  | ((value: RawValueType | LabelInValueType, option: OptionType) => void)
-  | ((value: ValueType, option: OptionType) => void);
+export type SelectHandler<ValueType, OptionType extends BaseOptionType = DefaultOptionType> = (
+  value: ValueType,
+  option: OptionType,
+) => void;
 
 type ArrayElementType<T> = T extends (infer E)[] ? E : T;
 

--- a/tests/type.test.tsx
+++ b/tests/type.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Select from '../src';
+
+describe('Select.typescript', () => {
+  it('Select.items', () => {
+    const select = (
+      <Select
+        onSelect={(value: string) => {
+          console.log(value);
+        }}
+      >
+        <Select.Option value="jack">jack</Select.Option>
+      </Select>
+    );
+
+    expect(select).toBeTruthy();
+  });
+
+  it('Select.items Customizable ValueType', () => {
+    const select = (
+      <Select<string, { value: string; title: string }>
+        defaultValue="TEAM_1"
+        showSearch
+        style={{ width: 200 }}
+        optionFilterProp="children"
+        onSelect={(_, option) => {
+          console.log(option);
+        }}
+        filterOption={(input, option) =>
+          (option && option.title.toLowerCase().indexOf(input.toLowerCase()) >= 0) ?? false
+        }
+      >
+        <Select.Option key="TEAM_1" value="TEAM_1" title="Team 1">
+          Team 131
+        </Select.Option>
+        ))
+      </Select>
+    );
+
+    expect(select).toBeTruthy();
+  });
+});


### PR DESCRIPTION
[#34201](https://github.com/ant-design/ant-design/issues/34201#issuecomment-1308940256)

SelectHandler\<ValueType, OptionType extends BaseOptionType = DefaultOptionType\> = (
  value: ValueType,
  option: OptionType,
) => void;

onChange?: (value: ValueType, option: OptionType | OptionType[]) => void;

修复后，onselect类型定义和onchange的类型是相似的