### PR TITLE
fix: Select width 0px when searching

### DIFF
--- a/docs/examples/single.tsx
+++ b/docs/examples/single.tsx
@@ -60,14 +60,13 @@ class Test extends React.Component {
 
         <h2>Single Select</h2>
 
-        <div style={{ width: 300 }}>
+        <div>
           <Select
             autoFocus
             id="my-select"
             value={value}
             placeholder="placeholder"
             showSearch
-            style={{ width: 500 }}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onSearch={this.onSearch}

--- a/src/Selector/SingleSelector.tsx
+++ b/src/Selector/SingleSelector.tsx
@@ -61,14 +61,18 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
   // Get title
   const title = getTitle(item);
 
+  // 当 Select 已经选中了选型时，placeholder 隐藏，但留在原地占位，内容是选中项文本，这样宽度不会缩减为 0px
+  // https://github.com/ant-design/ant-design/issues/27688
+  // https://github.com/ant-design/ant-design/issues/41530
   const renderPlaceholder = () => {
-    if (item) {
-      return null;
-    }
-    const hiddenStyle = hasTextInput ? { visibility: 'hidden' as const } : undefined;
+    const hiddenStyle = (hasTextInput || item)
+      ? { visibility: 'hidden' } as React.CSSProperties : undefined;
     return (
-      <span className={`${prefixCls}-selection-placeholder`} style={hiddenStyle}>
-        {placeholder}
+      <span
+        className={`${prefixCls}-selection-placeholder`}
+        style={hiddenStyle}
+      >
+        {item ? item.label : placeholder}
       </span>
     );
   };

--- a/tests/Combobox.test.tsx
+++ b/tests/Combobox.test.tsx
@@ -74,7 +74,7 @@ describe('Select.Combobox', () => {
     expect(wrapper.find('input').props().value).toBe('');
     expect(wrapper.find('.rc-select-selection-placeholder').text()).toEqual('placeholder');
     wrapper.find('input').simulate('change', { target: { value: '1' } });
-    expect(wrapper.find('.rc-select-selection-placeholder').length).toBeFalsy();
+    expect(wrapper.find('.rc-select-selection-placeholder').length).toBe(1);
     expect(wrapper.find('input').props().value).toBe('1');
   });
 

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -595,18 +595,16 @@ describe('Select.Basic', () => {
       expect(wrapper.find('.rc-select').getDOMNode().className).toContain('-focus');
     });
 
-    it('click placeholder should trigger onFocus', () => {
-      const wrapper2 = mount(
+    it('focus input when placeholder is clicked', () => {
+      const wrapper = mount(
         <Select placeholder="xxxx">
           <Option value="1">1</Option>
           <Option value="2">2</Option>
         </Select>,
       );
-
-      const inputSpy = jest.spyOn(wrapper2.find('input').instance(), 'focus' as any);
-
-      wrapper2.find('.rc-select-selection-placeholder').simulate('mousedown');
-      wrapper2.find('.rc-select-selection-placeholder').simulate('click');
+      const inputSpy = jest.spyOn(wrapper.find('input').instance(), 'focus' as any);
+      wrapper.find('.rc-select-selection-placeholder').simulate('mousedown');
+      wrapper.find('.rc-select-selection-placeholder').simulate('click');
       expect(inputSpy).toHaveBeenCalled();
     });
   });
@@ -814,19 +812,6 @@ describe('Select.Basic', () => {
 
     selectItem(wrapper);
     expectOpen(wrapper, false);
-  });
-
-  it('focus input when placeholder is clicked', () => {
-    const wrapper = mount(
-      <Select placeholder="select">
-        <Option value="1">1</Option>
-      </Select>,
-    );
-
-    const focusSpy = jest.spyOn(wrapper.find('input').instance(), 'focus' as any);
-    wrapper.find('.rc-select-selection-placeholder').simulate('mousedown');
-    wrapper.find('.rc-select-selection-placeholder').simulate('click');
-    expect(focusSpy).toHaveBeenCalled();
   });
 
   describe('combobox could customize input element', () => {
@@ -1736,32 +1721,6 @@ describe('Select.Basic', () => {
     });
   });
 
-  describe('show placeholder', () => {
-    it('when searchValue is controlled', () => {
-      const wrapper = mount(<Select searchValue="light" placeholder="bamboo" />);
-      expect(
-        wrapper.find('.rc-select-selection-placeholder').getDOMNode().hasAttribute('style'),
-      ).toBe(false);
-      toggleOpen(wrapper);
-      expect(
-        (wrapper.find('.rc-select-selection-placeholder').getDOMNode() as HTMLSpanElement).style
-          .visibility,
-      ).toBe('hidden');
-    });
-
-    it('when value is null', () => {
-      const wrapper = mount(<Select value={null} placeholder="bamboo" />);
-      expect(wrapper.find('.rc-select-selection-placeholder').length).toBeTruthy();
-    });
-
-    it('not when value is null but it is an Option', () => {
-      const wrapper = mount(
-        <Select value={null} placeholder="bamboo" options={[{ value: null, label: 'light' }]} />,
-      );
-      expect(wrapper.find('.rc-select-selection-placeholder').length).toBeFalsy();
-    });
-  });
-
   it('Remove options can keep the cache', () => {
     const wrapper = mount(<Select value={903} options={[{ value: 903, label: 'Bamboo' }]} />);
     expect(findSelection(wrapper).text()).toEqual('Bamboo');
@@ -1892,16 +1851,6 @@ describe('Select.Basic', () => {
     const wrapper = mount(<Select onClick={onClick} />);
     wrapper.simulate('click');
     expect(onClick).toHaveBeenCalled();
-  });
-
-  it('should hide placeholder if force closed and showSearch with searchValue', () => {
-    const wrapper = mount(
-      <Select showSearch searchValue="search" open={false} placeholder="placeholder" />,
-    );
-    expect(
-      (wrapper.find('.rc-select-selection-placeholder').getDOMNode() as HTMLSpanElement).style
-        .visibility,
-    ).toBe('hidden');
   });
 
   it('no warning for non-dom attr', () => {

--- a/tests/__snapshots__/Select.test.tsx.snap
+++ b/tests/__snapshots__/Select.test.tsx.snap
@@ -226,6 +226,12 @@ exports[`Select.Basic no search 1`] = `
     >
       1
     </span>
+    <span
+      class="rc-select-selection-placeholder"
+      style="visibility:hidden"
+    >
+      1
+    </span>
   </div>
   <span
     aria-hidden="true"
@@ -270,6 +276,12 @@ exports[`Select.Basic render renders aria-attributes correctly 1`] = `
     <span
       class="antd-selection-item"
       title="2"
+    >
+      2
+    </span>
+    <span
+      class="antd-selection-placeholder"
+      style="visibility:hidden"
     >
       2
     </span>
@@ -325,6 +337,12 @@ exports[`Select.Basic render renders correctly 1`] = `
     <span
       class="antd-selection-item"
       title="2"
+    >
+      2
+    </span>
+    <span
+      class="antd-selection-placeholder"
+      style="visibility:hidden"
     >
       2
     </span>
@@ -385,6 +403,12 @@ exports[`Select.Basic render renders data-attributes correctly 1`] = `
     >
       2
     </span>
+    <span
+      class="antd-selection-placeholder"
+      style="visibility:hidden"
+    >
+      2
+    </span>
   </div>
   <span
     aria-hidden="true"
@@ -442,6 +466,12 @@ exports[`Select.Basic render renders disabled select correctly 1`] = `
     >
       2
     </span>
+    <span
+      class="antd-selection-placeholder"
+      style="visibility:hidden"
+    >
+      2
+    </span>
   </div>
   <span
     aria-hidden="true"
@@ -483,6 +513,12 @@ exports[`Select.Basic render renders dropdown correctly 1`] = `
     <span
       class="antd-selection-item"
       title="2"
+    >
+      2
+    </span>
+    <span
+      class="antd-selection-placeholder"
+      style="visibility:hidden"
     >
       2
     </span>
@@ -672,6 +708,12 @@ exports[`Select.Basic render renders role prop correctly 1`] = `
     >
       2
     </span>
+    <span
+      class="antd-selection-placeholder"
+      style="visibility:hidden"
+    >
+      2
+    </span>
   </div>
   <span
     aria-hidden="true"
@@ -728,6 +770,12 @@ exports[`Select.Basic should contain falsy children 1`] = `
     <span
       class="rc-select-selection-item"
       title="1"
+    >
+      1
+    </span>
+    <span
+      class="rc-select-selection-placeholder"
+      style="visibility:hidden"
     >
       1
     </span>

--- a/tests/placeholder.test.tsx
+++ b/tests/placeholder.test.tsx
@@ -1,0 +1,43 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import Select from '../src';
+import { toggleOpen } from './utils/common';
+
+describe('Select placeholder', () => {
+  it('when searchValue is controlled', () => {
+    const wrapper = mount(<Select searchValue="light" placeholder="bamboo" />);
+    expect(
+      wrapper.find('.rc-select-selection-placeholder').getDOMNode().hasAttribute('style'),
+    ).toBe(false);
+    toggleOpen(wrapper);
+    expect(
+      (wrapper.find('.rc-select-selection-placeholder').getDOMNode() as HTMLSpanElement).style
+        .visibility,
+    ).toBe('hidden');
+  });
+
+  it('when value is null', () => {
+    const wrapper = mount(<Select value={null} placeholder="bamboo" />);
+    expect(wrapper.find('.rc-select-selection-placeholder').length).toBe(1);
+    expect(wrapper.find('.rc-select-selection-placeholder').text()).toBe('bamboo');
+  });
+
+  it('not when value is null but it is an Option', () => {
+    const wrapper = mount(
+      <Select value={null} placeholder="bamboo" options={[{ value: null, label: 'light' }]} />,
+    );
+    expect(wrapper.find('.rc-select-selection-placeholder').length).toBe(1);
+    expect(wrapper.find('.rc-select-selection-placeholder').text()).toBe('light');
+  });
+
+  it('should hide placeholder if force closed and showSearch with searchValue', () => {
+    const wrapper = mount(
+      <Select showSearch searchValue="search" open={false} placeholder="placeholder" />,
+    );
+    expect(
+      (wrapper.find('.rc-select-selection-placeholder').getDOMNode() as HTMLSpanElement).style
+        .visibility,
+    ).toBe('hidden');
+    expect(wrapper.find('.rc-select-selection-placeholder').text()).toBe('placeholder');
+  });
+});


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/27688
close https://github.com/ant-design/ant-design/issues/41530

Select 未选 item 时，此时进行搜，placeholder 会用 `visibility: hidden` 的方式隐藏，但是元素还在，承担了占位的作用。

Select 选了 item 后，原先的逻辑是 placeholder 元素直接 `return null`，因此没有占位了，整个 input 缩为 `0px`。

这里的逻辑改为：都使用 `visibility: hidden` 的方式隐藏 placeholder。当 Select 选了 item 后，placeholder 隐藏但文本内容改为 item 内容用于宽度占位。这样搜索时宽度不会变。
