### PR TITLE
fix: fix weird behavior when using dynamic maxCountTag

### DIFF
--- a/src/hooks/useSelectTriggerControl.ts
+++ b/src/hooks/useSelectTriggerControl.ts
@@ -37,7 +37,7 @@ export default function useSelectTriggerControl(
       }
     }
 
-    window.addEventListener('mousedown', onGlobalMouseDown);
+    window.addEventListener('mousedown', onGlobalMouseDown, true);
     return () => window.removeEventListener('mousedown', onGlobalMouseDown);
   }, []);
 }


### PR DESCRIPTION
fix [Weird behavior when using dynamic maxCountTag. #42551](https://github.com/ant-design/ant-design/issues/42551)
> 我尝试去解决该问题，以下是我对该bug出现的缘由和涉及的知识，如有错误可以及时与我交流
##### 出现原因
 在issue中已经提供了复现的步骤，问题所在在于 ```onDropdownVisibleChange``` 被错误执行两次。问题出现缘由在于 ```maxTagCount```，当 ```maxTagCount``` 是动态变化时，```select``` 组件会进行一次页面更新。```react```所采用的是合成事件机制，而 ```select``` 组件因为需要实现点击其他区域时关闭 ```select``` 的操作，在 ```window``` 上绑定了一个 ```mousedown``` 事件。而在点击```select```组件输入框时，使用```react```合成事件```onMouseDown```，该事件会将```select```组件展开。而合成事件的```onMouseDown```会先于```windows```上的```mousedown```事件执行。问题出在于合成事件先执行时会展开```select```组件，随后```maxTagCount```发生变化，会产生一次回流更新(我不太清楚为什么会产生一次更新)，更新会导致原先的```event.target```被移除，导致后续出发```window```上的```mousedown```时不能正确判断元素是在```select```组件之内，因此会将```select```组件关闭。
##### 解决思路
 知道了问题出现的原因后，解决问题也有跟多方案。在这里采用了将 ```mousedown``` 提前至捕获阶段执行的方案。