### PR TITLE
fix(onBlur):  suppress close popover onBlur

### DIFF
--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -363,7 +363,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
     defaultValue: defaultOpen,
     value: open,
   });
-
+  
   let mergedOpen = rendered ? innerOpen : false;
 
   // Not trigger `open` in `combobox` when `notFoundContent` is empty
@@ -563,7 +563,6 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
   const onContainerBlur: React.FocusEventHandler<HTMLElement> = (...args) => {
     setMockFocused(false, () => {
       focusRef.current = false;
-      onToggleOpen(false);
     });
 
     if (disabled) {
@@ -641,12 +640,11 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
   }, [triggerOpen]);
 
   // Used for raw custom input trigger
-  let onTriggerVisibleChange: null | ((newOpen: boolean) => void);
-  if (customizeRawInputElement) {
-    onTriggerVisibleChange = (newOpen: boolean) => {
+
+   const onTriggerVisibleChange = (newOpen: boolean) => {
       onToggleOpen(newOpen);
     };
-  }
+  
 
   // Close when click on non-select element
   useSelectTriggerControl(


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/42924
resolve https://github.com/ant-design/ant-design/discussions/42863

https://stackblitz.com/edit/react-djm2de?file=index.tsx

把onBlur事件 从 inputContainer 移动到popover上

解决的问题: 
原先, 当点击按钮,弹窗打开时,popover就会意外关闭,
修复后: 当点击按钮,弹窗打开时,popover不会意外关闭

但是想要彻底解决问题, 还需要最后一步, modal组件的dialog容器onClick时 阻止事件冒泡, 这样应该不会触发popover上的onBlur

