### PR TITLE
Restore Standard Select Controls

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -160,6 +160,11 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
     }
   };
 
+  const onUpdateValue = (value: RawValueType) => {
+    if (value !== undefined) {
+      onSelect(value, { selected: !rawValues.has(value) });
+    }
+  };
   // ========================= Keyboard =========================
   React.useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
@@ -183,10 +188,16 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
             }
           }
 
+          const nextActiveIndex = getEnabledActiveIndex(activeIndex + offset, offset);
           if (offset !== 0) {
-            const nextActiveIndex = getEnabledActiveIndex(activeIndex + offset, offset);
             scrollIntoView(nextActiveIndex);
             setActive(nextActiveIndex, true);
+          }
+          const item = memoFlattenOptions[nextActiveIndex];
+          if (item && !item.data.disabled) {
+            onUpdateValue(item.value);
+          } else {
+            onUpdateValue(undefined);
           }
 
           break;


### PR DESCRIPTION
Vanilla HTML Selects standard controls allow for arrow keys up/down to select the previous/next option, and then when a user tabs, it keeps that selected option.  This commit implements that functionality into rc-select.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#technical_summary

This functionality has been asked for by the community for Ant Design over the years, see issue here:
close https://github.com/ant-design/ant-design/issues/26876

Please forgive me if I've done this PR incorrectly, I'm unfamiliar with the procedure, and if I did anything wrong, please let me know so that I can do better next time.