### PR TITLE
fix: use getComputedStyle instead getBoundingClientRect.

### DIFF
--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -618,7 +618,8 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
   useLayoutEffect(() => {
     if (triggerOpen) {
       // Guaranteed width accuracy 
-      const newWidth = Math.ceil(containerRef.current?.getBoundingClientRect().width);
+      const computedStyle = getComputedStyle(containerRef.current);
+      const newWidth = Number(computedStyle.width.replace('px', ''));
       if (containerWidth !== newWidth && !Number.isNaN(newWidth)) {
         setContainerWidth(newWidth);
       }

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1359,11 +1359,11 @@ describe('Select.Basic', () => {
     let domHook;
 
     beforeAll(() => {
-      domHook = spyElementPrototypes(HTMLElement, {
-        getBoundingClientRect: () => ({
-          width: 1000
-        }),
-      });
+      window.getComputedStyle = () => {
+        return {
+          width: '1000px',
+        } as CSSStyleDeclaration;
+      };
     });
 
     afterAll(() => {


### PR DESCRIPTION
使用getComputedStyle代替getBoundingClientRect解决[issue](https://github.com/ant-design/ant-design/issues/44354).

发现issue出现的原因是之前的一次修复使用了getBoundingClientRect 代替offsetWidth，目的是[解决offsetWidth只能读取整数的问题](https://github.com/react-component/select/pull/959)，但是这会取值到当前实际的宽度，即300px 乘以 1.5的缩放 总共450px， 当悬浮节点挂载在1.5缩放的div里后，之前设置的450px 会被再乘以1.5倍的缩放。

所以使用getComputedStyle读取width值，他可以读取到select的精确宽度。