### PR TITLE
fix: trigger onBlur does not require reset focused

### DIFF
--- a/src/BaseSelect.tsx
+++ b/src/BaseSelect.tsx
@@ -316,6 +316,7 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
   const triggerRef = React.useRef<RefTriggerProps>(null);
   const selectorRef = React.useRef<RefSelectorProps>(null);
   const listRef = React.useRef<RefOptionListProps>(null);
+  const blurRef = React.useRef<boolean>(false);
 
   /** Used for component focused management */
   const [mockFocused, setMockFocused, cancelSetMockFocused] = useDelayReset();
@@ -451,7 +452,8 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
       setInnerOpen(false);
     }
 
-    if (disabled) {
+    // After onBlur is triggered, the focused does not need to be reset
+    if (disabled && !blurRef.current) {
       setMockFocused(false);
     }
   }, [disabled]);
@@ -561,8 +563,11 @@ const BaseSelect = React.forwardRef((props: BaseSelectProps, ref: React.Ref<Base
   };
 
   const onContainerBlur: React.FocusEventHandler<HTMLElement> = (...args) => {
+    blurRef.current = true;
+
     setMockFocused(false, () => {
       focusRef.current = false;
+      blurRef.current = false;
       onToggleOpen(false);
     });
 

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -35,7 +35,7 @@ describe('Select.Focus', () => {
   it('after onBlur is triggered the focused does not need to be reset', () => {
     jest.useFakeTimers();
 
-    const onFocus = jest.fn()
+    const onFocus = jest.fn();
 
     const Demo: React.FC = () => {
       const [disabled, setDisabled] = useState(false);

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,7 +1,8 @@
-import { mount } from 'enzyme';
-import React from 'react';
+import { mount} from 'enzyme';
+import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import Select from '../src';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('Select.Focus', () => {
   it('disabled should reset focused', () => {
@@ -28,6 +29,38 @@ describe('Select.Focus', () => {
     });
     expect(wrapper.exists('.rc-select-focused')).toBeFalsy();
 
+    jest.useRealTimers();
+  });
+
+  it('after onBlur is triggered the focused does not need to be reset', () => {
+    jest.useFakeTimers();
+
+    const Demo: React.FC = () => {
+      const [disabled, setDisabled] = useState(false);
+      return (
+        <>
+          <Select disabled={disabled} onBlur={() => setDisabled(true)} />
+          <button onClick={() => setDisabled(false)} />
+        </>
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    fireEvent.focus(container.querySelector('input'));
+    jest.runAllTimers();
+
+    // trigger disabled
+    fireEvent.blur(container.querySelector('input'));
+    jest.runAllTimers();
+
+    // reset disabled
+    fireEvent.click(container.querySelector('button'));
+
+    fireEvent.focus(container.querySelector('input'));
+    jest.runAllTimers();
+
+    expect(container.querySelector('.rc-select-focused')).toBeTruthy();
     jest.useRealTimers();
   });
 

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -35,11 +35,13 @@ describe('Select.Focus', () => {
   it('after onBlur is triggered the focused does not need to be reset', () => {
     jest.useFakeTimers();
 
+    const onFocus = jest.fn()
+
     const Demo: React.FC = () => {
       const [disabled, setDisabled] = useState(false);
       return (
         <>
-          <Select disabled={disabled} onBlur={() => setDisabled(true)} />
+          <Select disabled={disabled} onFocus={onFocus} onBlur={() => setDisabled(true)} />
           <button onClick={() => setDisabled(false)} />
         </>
       );
@@ -54,13 +56,18 @@ describe('Select.Focus', () => {
     fireEvent.blur(container.querySelector('input'));
     jest.runAllTimers();
 
+    // reset focused
+    onFocus.mockReset();
+
+    expect(container.querySelector('.rc-select-disabled')).toBeTruthy();
+
     // reset disabled
     fireEvent.click(container.querySelector('button'));
-
     fireEvent.focus(container.querySelector('input'));
     jest.runAllTimers();
 
-    expect(container.querySelector('.rc-select-focused')).toBeTruthy();
+    expect(onFocus).toHaveBeenCalled();
+
     jest.useRealTimers();
   });
 

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,4 +1,4 @@
-import { mount} from 'enzyme';
+import { mount } from 'enzyme';
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import Select from '../src';


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/44619

问题出现原因：在 `Select` 触发 `onBlur` 后其 `disabled` 为 true 时触发了重置 focused 的操作，将 `onBlur` 要执行的回调给清除掉了。