### PR TITLE
feat: add more props to TransBtn

### DIFF
--- a/docs/examples/custom-icon.tsx
+++ b/docs/examples/custom-icon.tsx
@@ -22,10 +22,11 @@ const clearPath =
   ' 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h618c35.3 0 64-' +
   '28.7 64-64V306c0-35.3-28.7-64-64-64z';
 
-const menuItemSelectedIcon = (props) => {
-  const { ...p } = props;
-  return <span style={{ position: 'absolute', right: 0 }}>{p.isSelected ? '🌹' : '☑️'}</span>;
-};
+const menuItemSelectedIcon = (props) => (
+  <span style={{ position: 'absolute', right: 0, opacity: props.disabled ? 0.5 : 1 }}>
+    {props.isSelected ? '🌹' : '☑️'}
+  </span>
+);
 
 const singleItemIcon = (
   <span style={{ position: 'absolute', right: '0px' }} role="img" aria-label="rose">

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -372,7 +372,11 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
                 <TransBtn
                   className={`${itemPrefixCls}-option-state`}
                   customizeIcon={menuItemSelectedIcon}
-                  customizeIconProps={{ isSelected: selected }}
+                  customizeIconProps={{
+                    value,
+                    disabled,
+                    isSelected: selected,
+                  }}
                 >
                   {selected ? '✓' : null}
                 </TransBtn>

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1489,6 +1489,7 @@ describe('Select.Basic', () => {
 
   it('dropdown selection item customize icon', () => {
     const menuItemSelectedIcon = jest.fn();
+
     mount(
       <Select
         value="1"
@@ -1497,8 +1498,25 @@ describe('Select.Basic', () => {
         menuItemSelectedIcon={menuItemSelectedIcon}
       />,
     );
+    expect(menuItemSelectedIcon).toHaveBeenCalledWith({
+      value: '1',
+      disabled: undefined,
+      isSelected: true,
+    });
 
-    expect(menuItemSelectedIcon).toHaveBeenCalledWith({ isSelected: true });
+    mount(
+      <Select
+        value="1"
+        options={[{ value: '2', disabled: true } as any]}
+        open
+        menuItemSelectedIcon={menuItemSelectedIcon}
+      />,
+    );
+    expect(menuItemSelectedIcon).toHaveBeenCalledWith({
+      value: '2',
+      disabled: true,
+      isSelected: false,
+    });
   });
 
   it('keyDown & KeyUp event', () => {


### PR DESCRIPTION
# 需求

在我们项目的 UI 需求中，需要通过 option 的 `disabled` 和 `value` 来控制 icon 渲染，例如：

- 对于 disabled 的条目，需要展示一个 disabled 的 checkbox
- 对于特殊的 value，需要展示另一种 icon
- 否则，通过 `isSelected` 展示正常的 checkbox

目前 `menuItemSelectedIcon` 支持传入一个函数，但其中的参数只有一个 `{ isSelected: boolean }`，这个 PR 将 `value` 和 `disabled`添加进去，便于开发者使用。

如下图所示，第一条因为是 disabled 状态，所以右边的 icon 被设置为了 0.5 透明度。

<img width="544" alt="image" src="https://github.com/react-component/select/assets/27483702/a7395e17-3da8-4b97-ad74-cc2cd9c3e2c7">

# 影响面

- 行为一致：均为新增字段，因此之前的行为不会变
- 无需修改文档和类型：文档给的标注是 `(props: MenuItemProps) => ReactNode`，而 `MenuItemProps` 没有具体类型；ts 定义里面也没有固定类型