### PR TITLE
chore: rm option len match

### DIFF
--- a/docs/demo/scroll-loading.md
+++ b/docs/demo/scroll-loading.md
@@ -1,0 +1,2 @@
+## scroll loading
+<code src="../examples/scroll-loading.tsx">

--- a/docs/examples/scroll-loading.tsx
+++ b/docs/examples/scroll-loading.tsx
@@ -1,0 +1,41 @@
+import Select from 'rc-select';
+import React from 'react';
+import '../../assets/index.less';
+
+function genData(len: number) {
+  return new Array(len).fill(0).map((_, index) => ({
+    label: `label ${index}`,
+    value: index,
+  }));
+}
+
+const Loading = ({ onLoad }) => {
+  React.useEffect(() => {
+    setTimeout(onLoad, 1000);
+  }, []);
+
+  return <div>Loading...</div>;
+};
+
+export default () => {
+  const [options, setOptions] = React.useState(() => genData(10));
+
+  return (
+    <Select
+      defaultValue={0}
+      options={[
+        ...options,
+        {
+          label: (
+            <Loading
+              onLoad={() => {
+                setOptions(genData(options.length + 5));
+              }}
+            />
+          ),
+          value: 'loading',
+        },
+      ]}
+    />
+  );
+};

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -75,6 +75,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
 
   const scrollIntoView = (args: number | ScrollConfig) => {
     if (listRef.current) {
+      console.error('scroll!!!', args);
       listRef.current.scrollTo(typeof args === 'number' ? { index: args } : args);
     }
   };
@@ -146,7 +147,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
     }
 
     return () => clearTimeout(timeoutId);
-  }, [open, searchValue, flattenOptions.length]);
+  }, [open, searchValue]);
 
   // ========================== Values ==========================
   const onSelectValue = (value: RawValueType) => {

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -75,7 +75,6 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
 
   const scrollIntoView = (args: number | ScrollConfig) => {
     if (listRef.current) {
-      console.error('scroll!!!', args);
       listRef.current.scrollTo(typeof args === 'number' ? { index: args } : args);
     }
   };


### PR DESCRIPTION
仅在 打开 和 搜索 变化时滚动到选中项，数据长度变化时不做滚动以防止动态 `options` 的场景导致的无限滚动。

resolves https://github.com/ant-design/ant-design/issues/45137 #982