### PR TITLE
fix: combobox prevent behavior

### DIFF
--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -109,6 +109,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     mode,
     showSearch,
     tokenWithEnter,
+    disabled,
 
     autoClearSearchValue,
 
@@ -228,9 +229,10 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
   const onMouseDown: React.MouseEventHandler<HTMLElement> = (event) => {
     const inputMouseDown = getInputMouseDown();
 
-    // when mode is combobox, don't prevent default behavior
+    // when mode is combobox and it is disabled, don't prevent default behavior
     // https://github.com/ant-design/ant-design/issues/37320
-    if (event.target !== inputRef.current && !inputMouseDown && mode !== 'combobox') {
+    // https://github.com/ant-design/ant-design/issues/48281
+    if (event.target !== inputRef.current && !inputMouseDown && !(mode === 'combobox' && disabled)) {
       event.preventDefault();
     }
 

--- a/tests/Combobox.test.tsx
+++ b/tests/Combobox.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
 import '@testing-library/jest-dom';
-import { fireEvent, render } from '@testing-library/react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { resetWarned } from 'rc-util/lib/warning';
 import React, { act } from 'react';
@@ -604,4 +604,42 @@ describe('Select.Combobox', () => {
     const { container } = render(<Select mode="combobox" value={0} />);
     expect(container.querySelector('input')!.value).toBe('0');
   });
+
+  // https://github.com/ant-design/ant-design/issues/48281
+  describe('combobox mode onMouseDown event default behavior', () => {
+    it('should prevent default behavior when mode is combobox', () => {
+      const preventDefault = jest.fn();
+      const { container } = render(
+        <Select mode="combobox" value="1">
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>,
+      );
+      
+      const selectorEle = container.querySelector('.rc-select-selector');
+  
+      const mouseDownEvent = createEvent.mouseDown(selectorEle);
+      mouseDownEvent.preventDefault = preventDefault;
+      fireEvent(selectorEle, mouseDownEvent);
+      expect(preventDefault).toHaveBeenCalled();
+    })
+
+    it('should not prevent default behavior when mode is combobox and it is disabled', () => {
+      const preventDefault = jest.fn();
+      const { container } = render(
+        <Select mode="combobox" value="1" disabled>
+          <Option value="1">1</Option>
+          <Option value="2">2</Option>
+        </Select>,
+      );
+      
+      const selectorEle = container.querySelector('.rc-select-selector');
+  
+      const mouseDownEvent = createEvent.mouseDown(selectorEle);
+      mouseDownEvent.preventDefault = preventDefault;
+      fireEvent(selectorEle, mouseDownEvent);
+      expect(preventDefault).not.toHaveBeenCalled();
+    })
+  });
+  
 });


### PR DESCRIPTION
【原因】
[issues 48281](https://github.com/ant-design/ant-design/issues/48281) 反馈 AutoComplete 点击边缘，下拉框会跳动，经过排查发现是因为 rc-select 在 mode 为 combobox 的时候，没有禁止默认行为，导致内部 Input 会不断的失焦和聚焦，下拉会不断的展开和隐藏。

<img width="771" alt="image" src="https://github.com/react-component/select/assets/20812315/7172724b-a11e-4281-9c35-b942f777e8ae">

在源码中注释了，combobox 没有阻止默认行为的原因是为解决 [issues 37320](https://github.com/ant-design/ant-design/issues/37320) 即 combobox 禁用状态下，无法选中文字的问题

为了同时解决上面的问题，并且不影响原来的其他逻辑，我添加了禁用状态的限制条件