### PR TITLE
fix: Chrome render perf issue

### DIFF
--- a/src/BaseSelect/Polite.tsx
+++ b/src/BaseSelect/Polite.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import type { DisplayValueType } from '.';
+
+export interface PoliteProps {
+  visible: boolean;
+  values: DisplayValueType[];
+}
+
+export default function Polite(props: PoliteProps) {
+  const { visible, values } = props;
+
+  if (!visible) {
+    return null;
+  }
+
+  // Only cut part of values since it's a screen reader
+  const MAX_COUNT = 10;
+
+  return (
+    <span
+      aria-live="polite"
+      style={{ width: 0, height: 0, position: 'absolute', overflow: 'hidden', opacity: 0 }}
+    >
+      {/* Merge into one string to make screen reader work as expect */}
+      {`${values
+        .slice(0, MAX_COUNT)
+        .map(({ label, value }) => (['number', 'string'].includes(typeof label) ? label : value))
+        .join(', ')}`}
+      {values.length > MAX_COUNT ? ', ...' : null}
+    </span>
+  );
+}

--- a/src/BaseSelect/Polite.tsx
+++ b/src/BaseSelect/Polite.tsx
@@ -14,7 +14,7 @@ export default function Polite(props: PoliteProps) {
   }
 
   // Only cut part of values since it's a screen reader
-  const MAX_COUNT = 10;
+  const MAX_COUNT = 50;
 
   return (
     <span

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -7,12 +7,12 @@ import KeyCode from 'rc-util/lib/KeyCode';
 import { useComposeRef } from 'rc-util/lib/ref';
 import type { ScrollConfig, ScrollTo } from 'rc-virtual-list/lib/List';
 import * as React from 'react';
-import { useAllowClear } from './hooks/useAllowClear';
-import { BaseSelectContext } from './hooks/useBaseProps';
-import type { BaseSelectContextProps } from './hooks/useBaseProps';
-import useDelayReset from './hooks/useDelayReset';
-import useLock from './hooks/useLock';
-import useSelectTriggerControl from './hooks/useSelectTriggerControl';
+import { useAllowClear } from '../hooks/useAllowClear';
+import { BaseSelectContext } from '../hooks/useBaseProps';
+import type { BaseSelectContextProps } from '../hooks/useBaseProps';
+import useDelayReset from '../hooks/useDelayReset';
+import useLock from '../hooks/useLock';
+import useSelectTriggerControl from '../hooks/useSelectTriggerControl';
 import type {
   DisplayInfoType,
   DisplayValueType,
@@ -21,15 +21,16 @@ import type {
   RawValueType,
   RenderDOMFunc,
   RenderNode,
-} from './interface';
-import type { RefSelectorProps } from './Selector';
-import Selector from './Selector';
-import type { RefTriggerProps } from './SelectTrigger';
-import SelectTrigger from './SelectTrigger';
-import TransBtn from './TransBtn';
-import { getSeparatedContent, isValidCount } from './utils/valueUtil';
-import SelectContext from './SelectContext';
-import type { SelectContextProps } from './SelectContext';
+} from '../interface';
+import type { RefSelectorProps } from '../Selector';
+import Selector from '../Selector';
+import type { RefTriggerProps } from '../SelectTrigger';
+import SelectTrigger from '../SelectTrigger';
+import TransBtn from '../TransBtn';
+import { getSeparatedContent, isValidCount } from '../utils/valueUtil';
+import SelectContext from '../SelectContext';
+import type { SelectContextProps } from '../SelectContext';
+import Polite from './Polite';
 
 export type {
   DisplayInfoType,
@@ -816,19 +817,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
         onFocus={onContainerFocus}
         onBlur={onContainerBlur}
       >
-        {mockFocused && !mergedOpen && (
-          <span
-            aria-live="polite"
-            style={{ width: 0, height: 0, position: 'absolute', overflow: 'hidden', opacity: 0 }}
-          >
-            {/* Merge into one string to make screen reader work as expect */}
-            {`${displayValues
-              .map(({ label, value }) =>
-                ['number', 'string'].includes(typeof label) ? label : value,
-              )
-              .join(', ')}`}
-          </span>
-        )}
+        <Polite visible={mockFocused && !mergedOpen} values={displayValues} />
         {selectorNode}
         {arrowNode}
         {mergedAllowClear && clearNode}

--- a/tests/BaseSelect.test.tsx
+++ b/tests/BaseSelect.test.tsx
@@ -62,6 +62,43 @@ describe('BaseSelect', () => {
     jest.useRealTimers();
   });
 
+  // https://github.com/ant-design/ant-design/issues/48833
+  it('a11y not block of Chrome render', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <BaseSelect
+        displayValues={Array.from({ length: 100 }).map((_, index) => ({
+          key: index,
+          value: index,
+          label: index,
+        }))}
+        id="test"
+        prefixCls="rc-select"
+        onDisplayValuesChange={() => {}}
+        searchValue=""
+        onSearch={() => {}}
+        OptionList={OptionList}
+        emptyOptions
+      />,
+    );
+
+    fireEvent.focus(container.querySelector('div.rc-select'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // We cut 50 count as hard code, its safe to adjust if refactor
+    const contentTxt = container.querySelector('span[aria-live=polite]')?.textContent;
+    expect(contentTxt).toBe(
+      `${Array.from({ length: 50 })
+        .map((_, index) => index)
+        .join(', ')}, ...`,
+    );
+
+    jest.useRealTimers();
+  });
+
   it('customize builtinPlacements should override default one', () => {
     const { container } = render(
       <BaseSelect

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1,10 +1,16 @@
 import type { LabelInValueType } from '@/Select';
-import { createEvent, fireEvent, render, render as testingRender } from '@testing-library/react';
+import {
+  createEvent,
+  fireEvent,
+  render,
+  render as testingRender,
+  act,
+} from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import { resetWarned } from 'rc-util/lib/warning';
 import type { ScrollConfig } from 'rc-virtual-list/lib/List';
-import React, { act } from 'react';
+import React from 'react';
 import type { SelectProps } from '../src';
 import Select, { OptGroup, Option, useBaseProps } from '../src';
 import type { BaseSelectRef } from '../src/BaseSelect';


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/48833

之前以为是下拉框的性能问题，做了 diff 后发现没有关系。排查了一下：

#### 当值包含中文时，在 Chrome 下会有巨幅的 layout 性能损耗，推测是中文的渲染问题。对于 Chrome 内核我们做不了，需要考虑做一些 workaround 绕过：

<img width="820" alt="截屏2024-05-09 14 31 13" src="https://github.com/react-component/select/assets/5378891/44aacb1a-8429-4b46-af8a-698f32a4a134">

#### 布局往前，有一个 29 微秒 的样式重绘。导致了巨大的 layout。

<img width="581" alt="截屏2024-05-09 14 31 52" src="https://github.com/react-component/select/assets/5378891/3478f276-64df-46fa-89a8-303dd4c710fa">

#### 定位到 React 中，查看相关插入节点

<img width="753" alt="截屏2024-05-09 14 32 56" src="https://github.com/react-component/select/assets/5378891/2449b4a8-ed34-4ae3-a25e-2390b9f30089">

#### 发现节点变化来自于 输入框 部分，的确和 下拉框 无关

<img width="555" alt="截屏2024-05-09 14 33 18" src="https://github.com/react-component/select/assets/5378891/aace339a-54ed-45d8-aafd-8c9904849213">

#### 变化来自于 a11y 的 polite 的自动提示相关

<img width="573" alt="截屏2024-05-09 14 34 07" src="https://github.com/react-component/select/assets/5378891/80bec860-4e38-4ad6-b2ae-8e32940691dc">

#### 代码中已经进行了空间裁剪，但是 Chrome 里会无视这部分进行全量渲染。考虑到读屏中，使用全量数据没有意义，调整 无障碍 提示量为 50 个。测试后修复：

<img width="790" alt="截屏2024-05-09 14 43 12" src="https://github.com/react-component/select/assets/5378891/973f5215-f44f-419f-8298-0e0a171a5416">


