### PR TITLE
fix: React 18.3 warning

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -764,7 +764,12 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       builtinPlacements={builtinPlacements}
       getPopupContainer={getPopupContainer}
       empty={emptyOptions}
-      getTriggerDOMNode={() => selectorDomRef.current}
+      getTriggerDOMNode={(node) =>
+        // TODO: This is workaround and should be removed in `rc-select`
+        // And use new standard `nativeElement` for ref.
+        // But we should update `rc-resize-observer` first.
+        selectorDomRef.current || node
+      }
       onPopupVisibleChange={onTriggerVisibleChange}
       onPopupMouseEnter={onPopupMouseEnter}
     >

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -73,7 +73,7 @@ export interface SelectTriggerProps {
   dropdownAlign: AlignType;
   empty: boolean;
 
-  getTriggerDOMNode: () => HTMLElement;
+  getTriggerDOMNode: (node: HTMLElement) => HTMLElement;
   onPopupVisibleChange?: (visible: boolean) => void;
 
   onPopupMouseEnter: () => void;

--- a/tests/React.test.tsx
+++ b/tests/React.test.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import Select from '../src';
+import { injectRunAllTimers } from './utils/common';
+import { render } from '@testing-library/react';
+
+describe('React', () => {
+  injectRunAllTimers(jest);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('not warning findDOMNode', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<Select open getRawInputElement={() => <a />} />);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
最好的解法是底层需要把相关组件都翻成 `nativeElement` 再通过 `rc-util/findDOMNode` 代理掉元素查询。不过工程略大，先在 Select 侧做一个兜底。