### PR TITLE
fix: fix typing of optionRender

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -143,7 +143,7 @@ export interface SelectProps<ValueType = any, OptionType extends BaseOptionType 
   children?: React.ReactNode;
   options?: OptionType[];
   optionRender?: (
-    oriOption: FlattenOptionData<BaseOptionType>,
+    oriOption: FlattenOptionData<OptionType>,
     info: { index: number },
   ) => React.ReactNode;
   defaultActiveFirstOption?: boolean;


### PR DESCRIPTION
This PR changes the type of `optionRender` to allow usage of a custom `OptionType`, rather than forcing `BaseOptionType`.