### PR TITLE
fix: filterSort don't work on group item

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -442,7 +442,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
             options: sorter(item.options),
           };
         }
-        return { ...item };
+        return item;
       });
     };
     const orderedFilteredOptions = React.useMemo(() => {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -439,7 +439,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
         if (Array.isArray(item.options)) {
           return {
             ...item,
-            options: sorter(item.options),
+            options: item.options.length > 0 ? sorter(item.options) : item.options,
           };
         }
         return item;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -431,8 +431,8 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       mergedSearchValue,
       mergedFieldNames,
     ]);
-    const sorter = (options: DefaultOptionType[]) => {
-      const sortedOptions = [...options].sort((a, b) =>
+    const sorter = (inputOptions: DefaultOptionType[]) => {
+      const sortedOptions = [...inputOptions].sort((a, b) =>
         filterSort(a, b, { searchValue: mergedSearchValue }),
       );
       return sortedOptions.map((item) => {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -431,15 +431,26 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       mergedSearchValue,
       mergedFieldNames,
     ]);
-
+    const sorter = (options: DefaultOptionType[]) => {
+      const sortedOptions = [...options].sort((a, b) =>
+        filterSort(a, b, { searchValue: mergedSearchValue }),
+      );
+      return sortedOptions.map((item) => {
+        if (Array.isArray(item.options)) {
+          return {
+            ...item,
+            options: sorter(item.options),
+          };
+        }
+        return { ...item };
+      });
+    };
     const orderedFilteredOptions = React.useMemo(() => {
       if (!filterSort) {
         return filledSearchOptions;
       }
 
-      return [...filledSearchOptions].sort((a, b) =>
-        filterSort(a, b, { searchValue: mergedSearchValue }),
-      );
+      return sorter(filledSearchOptions);
     }, [filledSearchOptions, filterSort, mergedSearchValue]);
 
     const displayOptions = React.useMemo(

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1947,6 +1947,41 @@ describe('Select.Basic', () => {
       'Communicated',
     );
   });
+  it('filterSort should work with search value when grouping', () => {
+    const { container } = render(
+      <Select
+        open
+        showSearch
+        searchValue="entry"
+        style={{ width: 100 }}
+        placeholder="Search to Select"
+        optionFilterProp="label"
+        filterSort={(optionA, optionB, info) => {
+          if (!info.searchValue) return 0;
+          const labelA = (optionA?.label ?? '').toLowerCase();
+          const labelB = (optionB?.label ?? '').toLowerCase();
+          const matchA = labelA.startsWith(info.searchValue);
+          const matchB = labelB.startsWith(info.searchValue);
+          if (matchA && !matchB) return -1;
+          if (!matchA && matchB) return 1;
+          return labelA.localeCompare(labelB);
+        }}
+        options={[
+          {
+            value: 'group1',
+            label: 'group1',
+            options: [
+              { label: 'Entry1', value: 'Entry1' },
+              { label: 'Entry2', value: 'Entry2' },
+              { label: 'Entry3', value: 'Entry3' },
+              { label: 'Entry', value: 'Entry' },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(container.querySelector('.rc-select-item-option-grouped').textContent).toBe('Entry');
+  });
 
   it('correctly handles the `tabIndex` prop', () => {
     const { container } = render(<Select tabIndex={0} />);

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1947,6 +1947,7 @@ describe('Select.Basic', () => {
       'Communicated',
     );
   });
+
   it('filterSort should work with search value when grouping', () => {
     const { container } = render(
       <Select


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->



### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/ant-design/ant-design/issues/50003
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案
 fix https://github.com/ant-design/ant-design/issues/50003

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->



| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  Solve the problem of invalid sorting within groups when grouping       |
| 🇨🇳 中文 |     解决分组时分组内排序失效问题    |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 在选择组件中引入了新的排序功能，支持对选项进行排序，包括嵌套选项。

- **测试**
  - 新增测试用例，验证在分组选项场景下，`filterSort`属性的功能是否正常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->