### PR TITLE
fix: aria-selected should not always set to false under combobox mode

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -124,8 +124,24 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
 
   // https://github.com/ant-design/ant-design/issues/34975
   const isSelected = React.useCallback(
-    (value: RawValueType) => rawValues.has(value) && mode !== 'combobox',
+    (value: RawValueType) => {
+      if (mode === 'combobox') {
+        return false;
+      }
+      return rawValues.has(value);
+    },
     [mode, [...rawValues].toString(), rawValues.size],
+  );
+
+  // https://github.com/ant-design/ant-design/issues/48036
+  const isAriaSelected = React.useCallback(
+    (value: RawValueType) => {
+      if (mode === 'combobox') {
+        return String(value).toLowerCase() === searchValue.toLowerCase();
+      }
+      return rawValues.has(value);
+    },
+    [mode, searchValue, [...rawValues].toString(), rawValues.size],
   );
 
   // Auto scroll to item position in single mode
@@ -275,7 +291,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
         {...attrs}
         key={index}
         {...getItemAriaProps(item, index)}
-        aria-selected={isSelected(value)}
+        aria-selected={isAriaSelected(value)}
       >
         {value}
       </div>
@@ -360,7 +376,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
             <div
               {...pickAttrs(passedProps)}
               {...(!virtual ? getItemAriaProps(item, itemIndex) : {})}
-              aria-selected={selected}
+              aria-selected={isAriaSelected(value)}
               className={optionClassName}
               title={optionTitle}
               onMouseMove={() => {


### PR DESCRIPTION
### This is a 
bug fix related to accessibility

### Related Issues
This can fix the issue that aria-select is always set to false in autoComplete component (under combobox mode)
https://github.com/ant-design/ant-design/issues/48036

### Background
Although no option is considered permanently "selected" under the combobox mode (autoComplete), if the aria-selected is affected by this then it could violate the accessibility issue, hence I made a change to determine accessibnility selection (set aria-selected attribute) while still maintain the visual consistency


![image](https://github.com/user-attachments/assets/fea361ed-a345-4366-9dd4-0155c0e1b8a0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了`OptionList`组件以改善选择状态和可访问性，特别是在“combobox”模式下。
	- 新增了`isAriaSelected`函数，以支持更好的无障碍功能。
- **改进**
	- `aria-selected`属性现在使用`isAriaSelected`，确保无障碍状态反映最新逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->