### PR TITLE
fix: tab to select an active option

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -215,7 +215,8 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
           break;
         }
 
-        // >>> Select
+        // >>> Select (Tab / Enter)
+        case KeyCode.TAB:
         case KeyCode.ENTER: {
           // value
           const item = memoFlattenOptions[activeIndex];

--- a/tests/OptionList.test.tsx
+++ b/tests/OptionList.test.tsx
@@ -202,6 +202,46 @@ describe('OptionList', () => {
     expect(onSelect).toHaveBeenCalledWith('1', expect.objectContaining({ selected: true }));
   });
 
+  it('should tab key select an active option', () => {
+    const onActiveValue = jest.fn();
+    const onSelect = jest.fn();
+    const toggleOpen = jest.fn();
+    const listRef = React.createRef<RefOptionListProps>();
+
+    render(
+      generateList({
+        options: [{ value: '1' }, { value: '2' }],
+        onActiveValue,
+        onSelect,
+        toggleOpen,
+        ref: listRef,
+      }),
+    );
+
+    act(() => {
+      toggleOpen(true);
+    });
+
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.DOWN } as any);
+    });
+
+    expect(onActiveValue).toHaveBeenCalledWith(
+      '2',
+      expect.anything(),
+      expect.objectContaining({ source: 'keyboard' }),
+    );
+
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.TAB } as any);
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('2', expect.objectContaining({ selected: true }));
+
+    expect(toggleOpen).toHaveBeenCalledWith(false);
+  });
+
   // mocked how we detect running platform in test environment
   it('special key operation on Mac', () => {
     const onActiveValue = jest.fn();


### PR DESCRIPTION
### This is a
keyboard accessibility

### Background 
When the dropdown is open and an option is active, pressing Tab should select the currently active option.
Fix https://github.com/ant-design/ant-design/issues/26876

### Solution
- Handle the case for key TAB in onSelect event
- Added test case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 增强了`OptionList`组件的键盘导航功能，支持使用Tab和Enter键选择选项。
- **测试**
	- 添加了新的测试用例，验证Tab键选择活动选项的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->