### PR TITLE
feat: support overriding default component behavior for the onBlur event in tags mode

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -162,6 +162,10 @@ export interface SelectProps<ValueType = any, OptionType extends BaseOptionType 
   defaultValue?: ValueType | null;
   maxCount?: number;
   onChange?: (value: ValueType, option: OptionType | OptionType[]) => void;
+
+  // >>> tags mode only
+  onBlurRemoveSpace?: boolean;
+  onBlurAddValue?: boolean;
 }
 
 function isRawValue(value: DraftValueType): value is RawValueType {
@@ -210,6 +214,10 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       labelInValue,
       onChange,
       maxCount,
+
+      // tags mode only
+      onBlurRemoveSpace = true,
+      onBlurAddValue = true,
 
       ...restProps
     } = props;
@@ -575,14 +583,15 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
 
       // [Submit] Tag mode should flush input
       if (info.source === 'submit') {
-        const formatted = (searchText || '').trim();
+        const formatted = onBlurRemoveSpace ? (searchText || '').trim() : searchText || '';
         // prevent empty tags from appearing when you click the Enter button
-        if (formatted) {
+        if (formatted && onBlurAddValue) {
           const newRawValues = Array.from(new Set<RawValueType>([...rawValues, formatted]));
           triggerChange(newRawValues);
           triggerSelect(formatted, true);
-          setSearchValue('');
         }
+
+        setSearchValue('');
 
         return;
       }


### PR DESCRIPTION
为rc-select组件的标签模式下新增了两个参数：onBlurRemoveSpace和onBlurAddValue，用于覆盖组件内部默认的onBlur事件的行为

related to [Ant Design Team](https://github.com/ant-design)/[ant-design](https://github.com/ant-design)https://github.com/ant-design/ant-design/issues/51149
