### PR TITLE
fix: allow keyboard navigation on selected options when maxCount is reached

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -85,6 +85,17 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
     listRef.current?.scrollTo(typeof args === 'number' ? { index: args } : args);
   };
 
+  // https://github.com/ant-design/ant-design/issues/34975
+  const isSelected = React.useCallback(
+    (value: RawValueType) => {
+      if (mode === 'combobox') {
+        return false;
+      }
+      return rawValues.has(value);
+    },
+    [mode, [...rawValues].toString(), rawValues.size],
+  );
+
   // ========================== Active ==========================
   const getEnabledActiveIndex = (index: number, offset: number = 1): number => {
     const len = memoFlattenOptions.length;
@@ -94,7 +105,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
 
       const { group, data } = memoFlattenOptions[current] || {};
 
-      if (!group && !data?.disabled && !overMaxCount) {
+      if (!group && !data?.disabled && (isSelected(data.value) || !overMaxCount)) {
         return current;
       }
     }
@@ -121,17 +132,6 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
   useEffect(() => {
     setActive(defaultActiveFirstOption !== false ? getEnabledActiveIndex(0) : -1);
   }, [memoFlattenOptions.length, searchValue]);
-
-  // https://github.com/ant-design/ant-design/issues/34975
-  const isSelected = React.useCallback(
-    (value: RawValueType) => {
-      if (mode === 'combobox') {
-        return false;
-      }
-      return rawValues.has(value);
-    },
-    [mode, [...rawValues].toString(), rawValues.size],
-  );
 
   // https://github.com/ant-design/ant-design/issues/48036
   const isAriaSelected = React.useCallback(

--- a/tests/OptionList.test.tsx
+++ b/tests/OptionList.test.tsx
@@ -393,4 +393,70 @@ describe('OptionList', () => {
     });
     expect(global.scrollToArgs).toEqual({ index: 1 });
   });
+
+  // Test keyboard navigation behavior when maxCount limit is reached
+  // Verifies that:
+  // 1. Can navigate between already selected options
+  // 2. Cannot navigate to unselected options when maxCount is reached
+  // 3. Navigation wraps around between selected options
+  it('should allow keyboard navigation on selected options when reach maxCount', () => {
+    const onActiveValue = jest.fn();
+    const listRef = React.createRef<RefOptionListProps>();
+
+    render(
+      generateList({
+        multiple: true,
+        maxCount: 2,
+        options: [
+          { value: '1', label: '1' },
+          { value: '2', label: '2' },
+          { value: '3', label: '3' },
+        ],
+        values: new Set(['1', '2']), // Pre-select first two options
+        onActiveValue,
+        ref: listRef,
+      }),
+    );
+
+    onActiveValue.mockReset();
+
+    // Press down key - should move to option '2'
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.DOWN } as any);
+    });
+    expect(onActiveValue).toHaveBeenCalledWith(
+      '2',
+      expect.anything(),
+      expect.objectContaining({ source: 'keyboard' }),
+    );
+
+    // Press down key again - should wrap to option '1'
+    onActiveValue.mockReset();
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.DOWN } as any);
+    });
+    expect(onActiveValue).toHaveBeenCalledWith(
+      '1',
+      expect.anything(),
+      expect.objectContaining({ source: 'keyboard' }),
+    );
+
+    // Press up key - should move back to option '2'
+    onActiveValue.mockReset();
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.UP } as any);
+    });
+    expect(onActiveValue).toHaveBeenCalledWith(
+      '2',
+      expect.anything(),
+      expect.objectContaining({ source: 'keyboard' }),
+    );
+
+    // Press down key - should not activate option '3' since maxCount is reached
+    onActiveValue.mockReset();
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.DOWN } as any);
+    });
+    expect(onActiveValue).not.toHaveBeenCalledWith('3', expect.anything(), expect.anything());
+  });
 });


### PR DESCRIPTION
## 🐛 问题描述

rc-select 在达到 maxCount 时存在交互不一致的问题：
- 鼠标操作：可以继续激活（hover）已选中的选项
- 键盘操作：无法通过上下键激活任何选项（包括已选中的选项）
- ![8518369ec42b82f1d7acba429f78feaf](https://github.com/user-attachments/assets/8d57c953-5616-471b-bf84-e5b9f59c7422)

## 🔨 修复方案

统一了鼠标与键盘的交互行为：
- 当达到 maxCount 时，允许通过键盘上下键在已选中的选项间切换
- 保持未选中选项不可激活的限制
- 确保键盘操作的可访问性体验与鼠标操作保持一致

## 🧪 测试覆盖

添加了专门的测试用例验证：
- 达到 maxCount 时可以通过键盘在已选项间导航
- 上下键都能正常工作
- 未选中的选项会被正确跳过

## 📝 备注

这个修复提升了组件的可访问性，使键盘操作的用户获得与鼠标操作相同的体验。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 引入了新的选择逻辑，优化了选项列表组件的选择状态判断。
  
- **测试**
  - 增加了针对选项列表组件的键盘导航行为的测试，确保在达到最大选择数量时的用户交互限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->