### PR TITLE
fix: fix the edge mis trigger

### DIFF
--- a/src/utils/keyUtil.ts
+++ b/src/utils/keyUtil.ts
@@ -2,33 +2,39 @@ import KeyCode from 'rc-util/lib/KeyCode';
 
 /** keyCode Judgment function */
 export function isValidateOpenKey(currentKeyCode: number): boolean {
-  return ![
-    // System function button
-    KeyCode.ESC,
-    KeyCode.SHIFT,
-    KeyCode.BACKSPACE,
-    KeyCode.TAB,
-    KeyCode.WIN_KEY,
-    KeyCode.ALT,
-    KeyCode.META,
-    KeyCode.WIN_KEY_RIGHT,
-    KeyCode.CTRL,
-    KeyCode.SEMICOLON,
-    KeyCode.EQUALS,
-    KeyCode.CAPS_LOCK,
-    KeyCode.CONTEXT_MENU,
-    // F1-F12
-    KeyCode.F1,
-    KeyCode.F2,
-    KeyCode.F3,
-    KeyCode.F4,
-    KeyCode.F5,
-    KeyCode.F6,
-    KeyCode.F7,
-    KeyCode.F8,
-    KeyCode.F9,
-    KeyCode.F10,
-    KeyCode.F11,
-    KeyCode.F12,
-  ].includes(currentKeyCode);
+  return (
+    // Undefined for Edge bug:
+    // https://github.com/ant-design/ant-design/issues/51292
+    currentKeyCode &&
+    // Other keys
+    ![
+      // System function button
+      KeyCode.ESC,
+      KeyCode.SHIFT,
+      KeyCode.BACKSPACE,
+      KeyCode.TAB,
+      KeyCode.WIN_KEY,
+      KeyCode.ALT,
+      KeyCode.META,
+      KeyCode.WIN_KEY_RIGHT,
+      KeyCode.CTRL,
+      KeyCode.SEMICOLON,
+      KeyCode.EQUALS,
+      KeyCode.CAPS_LOCK,
+      KeyCode.CONTEXT_MENU,
+      // F1-F12
+      KeyCode.F1,
+      KeyCode.F2,
+      KeyCode.F3,
+      KeyCode.F4,
+      KeyCode.F5,
+      KeyCode.F6,
+      KeyCode.F7,
+      KeyCode.F8,
+      KeyCode.F9,
+      KeyCode.F10,
+      KeyCode.F11,
+      KeyCode.F12,
+    ].includes(currentKeyCode)
+  );
 }

--- a/tests/Accessibility.test.tsx
+++ b/tests/Accessibility.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import Select from '../src';
 import { injectRunAllTimers, expectOpen, keyDown } from './utils/common';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 describe('Select.Accessibility', () => {
   injectRunAllTimers(jest);
@@ -66,5 +66,40 @@ describe('Select.Accessibility', () => {
       document.querySelector('.rc-select-item-option-active .rc-select-item-option-content')!
         .textContent,
     ).toEqual('Light');
+  });
+
+  // https://github.com/ant-design/ant-design/issues/51292
+  it('edge bug', () => {
+    const { container } = render(
+      <Select
+        mode="combobox"
+        options={[
+          {
+            value: '123',
+          },
+          {
+            value: '1234',
+          },
+          {
+            value: '12345',
+          },
+        ]}
+        defaultValue="123"
+      />,
+    );
+
+    // Invalid key
+    keyDown(container.querySelector('input')!, undefined);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expectOpen(container, false);
+
+    // Valid key
+    keyDown(container.querySelector('input')!, KeyCode.A);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expectOpen(container);
   });
 });

--- a/tests/utils/common.ts
+++ b/tests/utils/common.ts
@@ -101,6 +101,9 @@ export function injectRunAllTimers(jest: Jest) {
 
 export function keyDown(element: HTMLElement, keyCode: number) {
   const event = createEvent.keyDown(element, { keyCode });
+  Object.defineProperties(event, {
+    which: { get: () => keyCode },
+  });
 
   act(() => {
     fireEvent(element, event);


### PR DESCRIPTION
Edge 自动完成的时候会莫名其妙触发一个 `keyDown` 事件到不相关的 input 上。目前只看出来最小复原结构为：

```html
<!-- 当存在 `value` 时，会被随机影响到 -->
<input value="xxxx" />
```

解法为对触发打开的判断加一个键位判断，为空的话就认为是无效键跳过开启。

fix https://github.com/ant-design/ant-design/issues/51292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了与 Edge 浏览器相关的键验证逻辑，确保只有有效的键码被评估。
  
- **Tests**
	- 为 `Select` 组件添加了新的测试用例，以验证无效和有效键的处理。
	- 在测试中引入了 `act` 函数，以确保状态更新正确处理。
  
- **Chores**
	- 更新了测试工具中的 `keyDown` 函数，以增强事件对象的功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->