### PR TITLE
feat:Retrieve the order parameter from rc-overflow and pass the value to the tagrender method

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -68,6 +68,7 @@ export type CustomTagProps = {
   onClose: (event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   closable: boolean;
   isMaxTag: boolean;
+  index: number;
 };
 
 export interface BaseSelectRef {

--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -131,6 +131,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     closable?: boolean,
     onClose?: React.MouseEventHandler,
     isMaxTag?: boolean,
+    order?: number,
   ) => {
     const onMouseDown = (e: React.MouseEvent) => {
       onPreventMouseDown(e);
@@ -141,6 +142,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
         {tagRender({
           label: content,
           value,
+          index: order,
           disabled: itemDisabled,
           closable,
           onClose,
@@ -150,7 +152,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     );
   };
 
-  const renderItem = (valueItem: DisplayValueType) => {
+  const renderItem = (valueItem: DisplayValueType, order: number) => {
     const { disabled: itemDisabled, label, value } = valueItem;
     const closable = !disabled && !itemDisabled;
 
@@ -173,7 +175,15 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     };
 
     return typeof tagRender === 'function'
-      ? customizeRenderSelector(value, displayLabel, itemDisabled, closable, onClose)
+      ? customizeRenderSelector(
+          value,
+          displayLabel,
+          itemDisabled,
+          closable,
+          onClose,
+          undefined,
+          order,
+        )
       : defaultRenderSelector(valueItem, displayLabel, itemDisabled, closable, onClose);
   };
 


### PR DESCRIPTION
修改背景：
https://github.com/ant-design/ant-design/issues/31501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为选择器组件的自定义标签渲染添加了索引支持，允许在渲染过程中获取标签的位置信息。

- **改进**
	- 增强了多选择器的渲染灵活性，通过引入 `order` 参数，使得可以根据标签的位置进行更精细的定制渲染。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->