### PR TITLE
feat：Give the parameter 'info' field 'index' of the renderItem method in rc-overflow to the tagRender method

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rc-component/trigger": "^2.1.1",
     "classnames": "2.x",
     "rc-motion": "^2.0.1",
-    "rc-overflow": "^1.3.1",
+    "rc-overflow": "^1.4.0",
     "rc-util": "^5.16.1",
     "rc-virtual-list": "^3.5.2"
   },

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -68,7 +68,7 @@ export type CustomTagProps = {
   onClose: (event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   closable: boolean;
   isMaxTag: boolean;
-  index?: number;
+  index: number;
 };
 
 export interface BaseSelectRef {

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -68,6 +68,7 @@ export type CustomTagProps = {
   onClose: (event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   closable: boolean;
   isMaxTag: boolean;
+  index?: number;
 };
 
 export interface BaseSelectRef {

--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -131,6 +131,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     closable?: boolean,
     onClose?: React.MouseEventHandler,
     isMaxTag?: boolean,
+    info?: { index: number },
   ) => {
     const onMouseDown = (e: React.MouseEvent) => {
       onPreventMouseDown(e);
@@ -141,6 +142,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
         {tagRender({
           label: content,
           value,
+          index: info?.index,
           disabled: itemDisabled,
           closable,
           onClose,
@@ -150,7 +152,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     );
   };
 
-  const renderItem = (valueItem: DisplayValueType) => {
+  const renderItem = (valueItem: DisplayValueType, info: { index: number }) => {
     const { disabled: itemDisabled, label, value } = valueItem;
     const closable = !disabled && !itemDisabled;
 
@@ -173,7 +175,15 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     };
 
     return typeof tagRender === 'function'
-      ? customizeRenderSelector(value, displayLabel, itemDisabled, closable, onClose)
+      ? customizeRenderSelector(
+          value,
+          displayLabel,
+          itemDisabled,
+          closable,
+          onClose,
+          undefined,
+          info,
+        )
       : defaultRenderSelector(valueItem, displayLabel, itemDisabled, closable, onClose);
   };
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -16,6 +16,7 @@ export interface DisplayValueType {
   label?: React.ReactNode;
   title?: React.ReactNode;
   disabled?: boolean;
+  index?: number;
 }
 
 export type RenderNode = React.ReactNode | ((props: any) => React.ReactNode);

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -14,6 +14,7 @@ import removeSelectedTest from './shared/removeSelectedTest';
 import maxTagRenderTest from './shared/maxTagRenderTest';
 import throwOptionValue from './shared/throwOptionValue';
 import { injectRunAllTimers, findSelection, expectOpen, toggleOpen, keyDown } from './utils/common';
+import type { CustomTagProps } from '@/BaseSelect';
 
 describe('Select.Tags', () => {
   injectRunAllTimers(jest);
@@ -299,6 +300,27 @@ describe('Select.Tags', () => {
 
       fireEvent.mouseDown(container.querySelector('span.A'));
       expectOpen(container, false);
+    });
+
+    it('tagRender props have index', () => {
+      const tagRender = (props: CustomTagProps) => {
+        const { index: tagIndex, label } = props;
+        return <div className={`${label}-${tagIndex}-test`}>{label}</div>;
+      };
+      const values = ['light', 'dark'];
+      const { container } = render(
+        <Select
+          mode="tags"
+          value={values}
+          tagRender={tagRender}
+          options={[{ value: 'light' }, { value: 'dark' }]}
+        />,
+      );
+      values.forEach((value, index) => {
+        const expectedText = `.${value}-${index}-test`;
+        const nodes = container.querySelectorAll(expectedText);
+        expect(nodes).toHaveLength(1);
+      });
     });
 
     it('disabled', () => {


### PR DESCRIPTION
修改背景：
https://github.com/ant-design/ant-design/issues/31501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 版本发布说明

- **新功能**
  - 在多选选择器中为标签渲染添加了索引支持
  - 扩展了显示值类型以包含可选的索引属性

- **依赖更新**
  - 将 `rc-overflow` 依赖版本从 `^1.3.1` 升级到 `^1.4.0`

- **测试**
  - 新增测试用例验证标签渲染的索引属性

这些更改提高了选择器组件的灵活性和渲染能力，允许更精细地控制和识别标签。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->