### PR TITLE
feat: rename dropdown to popup

### DIFF
--- a/docs/examples/auto-adjust-dropdown.tsx
+++ b/docs/examples/auto-adjust-dropdown.tsx
@@ -34,14 +34,14 @@ class Test extends React.Component {
       >
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <div>
-            <Select onChange={this.onChange} dropdownMatchSelectWidth={500} value={value}>
+            <Select onChange={this.onChange} popupMatchSelectWidth={500} value={value}>
               <Option value="1">Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack</Option>
               <Option value="2">Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy</Option>
               <Option value="3">Jill</Option>
             </Select>
           </div>
           <div>
-            <Select onChange={this.onChange} dropdownMatchSelectWidth={500} value={value}>
+            <Select onChange={this.onChange} popupMatchSelectWidth={500} value={value}>
               <Option value="1">Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack</Option>
               <Option value="2">Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy</Option>{' '}
               <Option value="3">Jill</Option>
@@ -50,7 +50,7 @@ class Test extends React.Component {
         </div>
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <div>
-            <Select onChange={this.onChange} dropdownMatchSelectWidth={500} value={value}>
+            <Select onChange={this.onChange} popupMatchSelectWidth={500} value={value}>
               <Option value="1">Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack</Option>
               <Option value="2">Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy</Option>
               <Option value="3">Jill</Option>
@@ -64,14 +64,14 @@ class Test extends React.Component {
           }}
         >
           <div>
-            <Select onChange={this.onChange} dropdownMatchSelectWidth={500} value={value}>
+            <Select onChange={this.onChange} popupMatchSelectWidth={500} value={value}>
               <Option value="1">Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack</Option>
               <Option value="2">Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy</Option>
               <Option value="3">Jill</Option>
             </Select>
           </div>
           <div>
-            <Select onChange={this.onChange} dropdownMatchSelectWidth={500} value={value}>
+            <Select onChange={this.onChange} popupMatchSelectWidth={500} value={value}>
               <Option value="1">Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack Jack</Option>
               <Option value="2">Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy Lucy</Option>
               <Option value="3">Jill</Option>

--- a/docs/examples/controlled.tsx
+++ b/docs/examples/controlled.tsx
@@ -43,7 +43,7 @@ class Controlled extends React.Component<{}, ControlledState> {
     console.log('onFocus');
   };
 
-  onDropdownVisibleChange = (open) => {
+  onPopupVisibleChange = (open) => {
     this.setState({ open });
   };
 
@@ -68,7 +68,7 @@ class Controlled extends React.Component<{}, ControlledState> {
             optionLabelProp="children"
             optionFilterProp="text"
             onChange={this.onChange}
-            onDropdownVisibleChange={this.onDropdownVisibleChange}
+            onPopupVisibleChange={this.onPopupVisibleChange}
           >
             <Option value="01" text="jack" title="jack">
               <b

--- a/docs/examples/dropdownRender.tsx
+++ b/docs/examples/dropdownRender.tsx
@@ -50,7 +50,7 @@ class Test extends React.Component {
             tokenSeparators={[' ', ',']}
             onFocus={() => console.log('focus')}
             onBlur={() => console.log('blur')}
-            dropdownRender={(menu) => (
+            popupRender={(menu) => (
               <React.Fragment>
                 <div
                   onClick={() => {

--- a/docs/examples/getPopupContainer.tsx
+++ b/docs/examples/getPopupContainer.tsx
@@ -75,9 +75,9 @@ class Test extends React.Component {
         >
           <h3 style={{ width: '100%' }}>Transform: 150%</h3>
           <MySelect />
-          <MySelect dropdownMatchSelectWidth />
-          <MySelect dropdownMatchSelectWidth={false} />
-          <MySelect dropdownMatchSelectWidth={300} />
+          <MySelect popupMatchSelectWidth />
+          <MySelect popupMatchSelectWidth={false} />
+          <MySelect popupMatchSelectWidth={300} />
         </div>
       </div>
     );

--- a/docs/examples/single-animation.tsx
+++ b/docs/examples/single-animation.tsx
@@ -21,7 +21,7 @@ const Test = () => (
         animation="slide-up"
         showSearch
         onChange={onChange}
-        dropdownStyle={{
+        popupStyle={{
           width: 'auto',
         }}
       >

--- a/docs/examples/single.tsx
+++ b/docs/examples/single.tsx
@@ -130,8 +130,8 @@ class Test extends React.Component {
             id="my-select-rtl"
             placeholder="rtl"
             direction="rtl"
-            dropdownMatchSelectWidth={300}
-            dropdownStyle={{ minWidth: 300 }}
+            popupMatchSelectWidth={300}
+            popupStyle={{ minWidth: 300 }}
             style={{ width: 500 }}
           >
             <Option value="1">1</Option>

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -337,7 +337,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
   const mergedPopupClassName = popupClassName ?? dropdownClassName;
   const mergedPopupRender = popupRender ?? dropdownRender;
   const mergedPopupAlign = popupAlign ?? dropdownAlign;
-
+  const mergedPopupMatchSelectWidth = popupMatchSelectWidth ?? dropdownMatchSelectWidth;
   // ============================= Mobile =============================
   const [mobile, setMobile] = React.useState(false);
   React.useEffect(() => {
@@ -800,7 +800,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       popupStyle={mergedPopupStyle}
       popupClassName={mergedPopupClassName}
       direction={direction}
-      popupMatchSelectWidth={popupMatchSelectWidth}
+      popupMatchSelectWidth={mergedPopupMatchSelectWidth}
       popupRender={mergedPopupRender}
       popupAlign={mergedPopupAlign}
       placement={placement}

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -156,8 +156,6 @@ export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttri
   // >>> Open
   open?: boolean;
   defaultOpen?: boolean;
-  /** @deprecated Please use `onPopupVisibleChange` instead */
-  onDropdownVisibleChange?: (open: boolean) => void;
   onPopupVisibleChange?: (open: boolean) => void;
 
   // >>> Customize Input
@@ -190,24 +188,10 @@ export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttri
   animation?: string;
   transitionName?: string;
 
-  /** @deprecated Please use `popupStyle` instead */
-  dropdownStyle?: React.CSSProperties;
   popupStyle?: React.CSSProperties;
-
-  /** @deprecated Please use `popupClassName` instead */
-  dropdownClassName?: string;
   popupClassName?: string;
-
-  /** @deprecated Please use `popupMatchSelectWidth` instead */
-  dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;
-
-  /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
   popupRender?: (menu: React.ReactElement) => React.ReactElement;
-
-  /** @deprecated Please use `popupAlign` instead */
-  dropdownAlign?: AlignType;
   popupAlign?: AlignType;
 
   placement?: Placement;
@@ -263,7 +247,6 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     // Open
     open,
     defaultOpen,
-    onDropdownVisibleChange,
     onPopupVisibleChange,
 
     // Active
@@ -288,15 +271,10 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     OptionList,
     animation,
     transitionName,
-    dropdownStyle,
     popupStyle,
-    dropdownClassName,
     popupClassName,
-    dropdownMatchSelectWidth,
     popupMatchSelectWidth,
-    dropdownRender,
     popupRender,
-    dropdownAlign,
     popupAlign,
     placement,
     builtinPlacements,
@@ -333,12 +311,6 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     delete domProps[propName];
   });
 
-  // ============================= Compitable =============================
-  const mergedPopupStyle = popupStyle ?? dropdownStyle;
-  const mergedPopupClassName = popupClassName ?? dropdownClassName;
-  const mergedPopupRender = popupRender ?? dropdownRender;
-  const mergedPopupAlign = popupAlign ?? dropdownAlign;
-  const mergedPopupMatchSelectWidth = popupMatchSelectWidth ?? dropdownMatchSelectWidth;
   // ============================= Mobile =============================
   const [mobile, setMobile] = React.useState(false);
   React.useEffect(() => {
@@ -419,12 +391,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
         setInnerOpen(nextOpen);
 
         if (mergedOpen !== nextOpen) {
-          onDropdownVisibleChange?.(nextOpen);
           onPopupVisibleChange?.(nextOpen);
         }
       }
     },
-    [disabled, mergedOpen, setInnerOpen, onDropdownVisibleChange, onPopupVisibleChange],
+    [disabled, mergedOpen, setInnerOpen, onPopupVisibleChange],
   );
 
   // ============================= Search =============================
@@ -798,12 +769,12 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       popupElement={optionList}
       animation={animation}
       transitionName={transitionName}
-      popupStyle={mergedPopupStyle}
-      popupClassName={mergedPopupClassName}
+      popupStyle={popupStyle}
+      popupClassName={popupClassName}
       direction={direction}
-      popupMatchSelectWidth={mergedPopupMatchSelectWidth}
-      popupRender={mergedPopupRender}
-      popupAlign={mergedPopupAlign}
+      popupMatchSelectWidth={popupMatchSelectWidth}
+      popupRender={popupRender}
+      popupAlign={popupAlign}
       placement={placement}
       builtinPlacements={builtinPlacements}
       getPopupContainer={getPopupContainer}

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -155,7 +155,9 @@ export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttri
   // >>> Open
   open?: boolean;
   defaultOpen?: boolean;
+  /** @deprecated Please use `onPopupVisibleChange` instead */
   onDropdownVisibleChange?: (open: boolean) => void;
+  onPopupVisibleChange?: (open: boolean) => void;
 
   // >>> Customize Input
   /** @private Internal usage. Do not use in your production. */
@@ -183,14 +185,30 @@ export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttri
   /** Selector remove icon */
   removeIcon?: RenderNode;
 
-  // >>> Dropdown
+  // >>> Dropdown/Popup
   animation?: string;
   transitionName?: string;
+
+  /** @deprecated Please use `popupStyle` instead */
   dropdownStyle?: React.CSSProperties;
+  popupStyle?: React.CSSProperties;
+
+  /** @deprecated Please use `popupClassName` instead */
   dropdownClassName?: string;
+  popupClassName?: string;
+
+  /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
+  popupMatchSelectWidth?: boolean | number;
+
+  /** @deprecated Please use `popupRender` instead */
   dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
+  popupRender?: (menu: React.ReactElement) => React.ReactElement;
+
+  /** @deprecated Please use `popupAlign` instead */
   dropdownAlign?: AlignType;
+  popupAlign?: AlignType;
+
   placement?: Placement;
   builtinPlacements?: BuildInPlacements;
   getPopupContainer?: RenderDOMFunc;
@@ -245,6 +263,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     open,
     defaultOpen,
     onDropdownVisibleChange,
+    onPopupVisibleChange,
 
     // Active
     activeValue,
@@ -269,10 +288,15 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     animation,
     transitionName,
     dropdownStyle,
+    popupStyle,
     dropdownClassName,
+    popupClassName,
     dropdownMatchSelectWidth,
+    popupMatchSelectWidth,
     dropdownRender,
+    popupRender,
     dropdownAlign,
+    popupAlign,
     placement,
     builtinPlacements,
     getPopupContainer,
@@ -307,6 +331,12 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
   omitDomProps?.forEach((propName) => {
     delete domProps[propName];
   });
+
+  // ============================= Compitable =============================
+  const mergedPopupStyle = popupStyle ?? dropdownStyle;
+  const mergedPopupClassName = popupClassName ?? dropdownClassName;
+  const mergedPopupRender = popupRender ?? dropdownRender;
+  const mergedPopupAlign = popupAlign ?? dropdownAlign;
 
   // ============================= Mobile =============================
   const [mobile, setMobile] = React.useState(false);
@@ -389,10 +419,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
 
         if (mergedOpen !== nextOpen) {
           onDropdownVisibleChange?.(nextOpen);
+          onPopupVisibleChange?.(nextOpen);
         }
       }
     },
-    [disabled, mergedOpen, setInnerOpen, onDropdownVisibleChange],
+    [disabled, mergedOpen, setInnerOpen, onDropdownVisibleChange, onPopupVisibleChange],
   );
 
   // ============================= Search =============================
@@ -766,12 +797,12 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       popupElement={optionList}
       animation={animation}
       transitionName={transitionName}
-      dropdownStyle={dropdownStyle}
-      dropdownClassName={dropdownClassName}
+      popupStyle={mergedPopupStyle}
+      popupClassName={mergedPopupClassName}
       direction={direction}
-      dropdownMatchSelectWidth={dropdownMatchSelectWidth}
-      dropdownRender={dropdownRender}
-      dropdownAlign={dropdownAlign}
+      popupMatchSelectWidth={popupMatchSelectWidth}
+      popupRender={mergedPopupRender}
+      popupAlign={mergedPopupAlign}
       placement={placement}
       builtinPlacements={builtinPlacements}
       getPopupContainer={getPopupContainer}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -180,8 +180,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       // Select
       onSelect,
       onDeselect,
-      dropdownMatchSelectWidth = true,
-      popupMatchSelectWidth = dropdownMatchSelectWidth,
+      popupMatchSelectWidth = true,
 
       // Options
       filterOption,

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -181,6 +181,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       onSelect,
       onDeselect,
       dropdownMatchSelectWidth = true,
+      popupMatchSelectWidth = dropdownMatchSelectWidth,
 
       // Options
       filterOption,
@@ -608,8 +609,10 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
     };
 
     // ========================== Context ===========================
+    const mergedPopupMatchSelectWidth = popupMatchSelectWidth ?? dropdownMatchSelectWidth;
+
     const selectContext = React.useMemo<SelectContextProps>(() => {
-      const realVirtual = virtual !== false && dropdownMatchSelectWidth !== false;
+      const realVirtual = virtual !== false && mergedPopupMatchSelectWidth !== false;
       return {
         ...parsedOptions,
         flattenOptions: displayOptions,
@@ -638,7 +641,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       rawValues,
       mergedFieldNames,
       virtual,
-      dropdownMatchSelectWidth,
+      mergedPopupMatchSelectWidth,
       direction,
       listHeight,
       listItemHeight,
@@ -675,7 +678,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
           onSearch={onInternalSearch}
           autoClearSearchValue={autoClearSearchValue}
           onSearchSplit={onInternalSearchSplit}
-          dropdownMatchSelectWidth={dropdownMatchSelectWidth}
+          popupMatchSelectWidth={mergedPopupMatchSelectWidth}
           // >>> OptionList
           OptionList={OptionList}
           emptyOptions={!displayOptions.length}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -609,10 +609,8 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
     };
 
     // ========================== Context ===========================
-    const mergedPopupMatchSelectWidth = popupMatchSelectWidth ?? dropdownMatchSelectWidth;
-
     const selectContext = React.useMemo<SelectContextProps>(() => {
-      const realVirtual = virtual !== false && mergedPopupMatchSelectWidth !== false;
+      const realVirtual = virtual !== false && popupMatchSelectWidth !== false;
       return {
         ...parsedOptions,
         flattenOptions: displayOptions,
@@ -641,7 +639,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       rawValues,
       mergedFieldNames,
       virtual,
-      mergedPopupMatchSelectWidth,
+      popupMatchSelectWidth,
       direction,
       listHeight,
       listItemHeight,
@@ -678,7 +676,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
           onSearch={onInternalSearch}
           autoClearSearchValue={autoClearSearchValue}
           onSearchSplit={onInternalSearchSplit}
-          popupMatchSelectWidth={mergedPopupMatchSelectWidth}
+          popupMatchSelectWidth={popupMatchSelectWidth}
           // >>> OptionList
           OptionList={OptionList}
           emptyOptions={!displayOptions.length}

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -5,10 +5,10 @@ import * as React from 'react';
 import type { Placement, RenderDOMFunc } from './BaseSelect';
 
 const getBuiltInPlacements = (
-  dropdownMatchSelectWidth: number | boolean,
+  popupMatchSelectWidth: number | boolean,
 ): Record<string, AlignType> => {
   // Enable horizontal overflow auto-adjustment when a custom dropdown width is provided
-  const adjustX = dropdownMatchSelectWidth === true ? 0 : 1;
+  const adjustX = popupMatchSelectWidth === true ? 0 : 1;
   return {
     bottomLeft: {
       points: ['tl', 'bl'],
@@ -64,13 +64,13 @@ export interface SelectTriggerProps {
   transitionName?: string;
   placement?: Placement;
   builtinPlacements?: BuildInPlacements;
-  dropdownStyle: React.CSSProperties;
-  dropdownClassName: string;
+  popupStyle: React.CSSProperties;
+  popupClassName: string;
   direction: string;
-  dropdownMatchSelectWidth?: boolean | number;
-  dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
+  popupMatchSelectWidth?: boolean | number;
+  popupRender?: (menu: React.ReactElement) => React.ReactElement;
   getPopupContainer?: RenderDOMFunc;
-  dropdownAlign: AlignType;
+  popupAlign: AlignType;
   empty: boolean;
 
   getTriggerDOMNode: (node: HTMLElement) => HTMLElement;
@@ -91,14 +91,14 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
     popupElement,
     animation,
     transitionName,
-    dropdownStyle,
-    dropdownClassName,
+    popupStyle,
+    popupClassName,
     direction = 'ltr',
     placement,
     builtinPlacements,
-    dropdownMatchSelectWidth,
-    dropdownRender,
-    dropdownAlign,
+    popupMatchSelectWidth,
+    popupRender,
+    popupAlign,
     getPopupContainer,
     empty,
     getTriggerDOMNode,
@@ -107,38 +107,38 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
     ...restProps
   } = props;
 
-  const dropdownPrefixCls = `${prefixCls}-dropdown`;
+  const popupPrefixCls = `${prefixCls}-dropdown`;
 
   let popupNode = popupElement;
-  if (dropdownRender) {
-    popupNode = dropdownRender(popupElement);
+  if (popupRender) {
+    popupNode = popupRender(popupElement);
   }
 
   const mergedBuiltinPlacements = React.useMemo(
-    () => builtinPlacements || getBuiltInPlacements(dropdownMatchSelectWidth),
-    [builtinPlacements, dropdownMatchSelectWidth],
+    () => builtinPlacements || getBuiltInPlacements(popupMatchSelectWidth),
+    [builtinPlacements, popupMatchSelectWidth],
   );
 
   // ===================== Motion ======================
-  const mergedTransitionName = animation ? `${dropdownPrefixCls}-${animation}` : transitionName;
+  const mergedTransitionName = animation ? `${popupPrefixCls}-${animation}` : transitionName;
 
   // =================== Popup Width ===================
-  const isNumberPopupWidth = typeof dropdownMatchSelectWidth === 'number';
+  const isNumberPopupWidth = typeof popupMatchSelectWidth === 'number';
 
   const stretch = React.useMemo(() => {
     if (isNumberPopupWidth) {
       return null;
     }
 
-    return dropdownMatchSelectWidth === false ? 'minWidth' : 'width';
-  }, [dropdownMatchSelectWidth, isNumberPopupWidth]);
+    return popupMatchSelectWidth === false ? 'minWidth' : 'width';
+  }, [popupMatchSelectWidth, isNumberPopupWidth]);
 
-  let popupStyle = dropdownStyle;
+  let mergedPopupStyle = popupStyle;
 
   if (isNumberPopupWidth) {
-    popupStyle = {
+    mergedPopupStyle = {
       ...popupStyle,
-      width: dropdownMatchSelectWidth,
+      width: popupMatchSelectWidth,
     };
   }
 
@@ -156,18 +156,18 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
       hideAction={onPopupVisibleChange ? ['click'] : []}
       popupPlacement={placement || (direction === 'rtl' ? 'bottomRight' : 'bottomLeft')}
       builtinPlacements={mergedBuiltinPlacements}
-      prefixCls={dropdownPrefixCls}
+      prefixCls={popupPrefixCls}
       popupTransitionName={mergedTransitionName}
       popup={<div onMouseEnter={onPopupMouseEnter}>{popupNode}</div>}
       ref={triggerPopupRef}
       stretch={stretch}
-      popupAlign={dropdownAlign}
+      popupAlign={popupAlign}
       popupVisible={visible}
       getPopupContainer={getPopupContainer}
-      popupClassName={classNames(dropdownClassName, {
-        [`${dropdownPrefixCls}-empty`]: empty,
+      popupClassName={classNames(popupClassName, {
+        [`${popupPrefixCls}-empty`]: empty,
       })}
-      popupStyle={popupStyle}
+      popupStyle={mergedPopupStyle}
       getTriggerDOMNode={getTriggerDOMNode}
       onPopupVisibleChange={onPopupVisibleChange}
     >

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -107,6 +107,12 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
     ...restProps
   } = props;
 
+  // We still use `dropdown` className to keep compatibility
+  // This is used for:
+  // 1. Styles
+  // 2. Animation
+  // 3. Theme customization
+  // Please do not modify this since it's a breaking change
   const popupPrefixCls = `${prefixCls}-dropdown`;
 
   let popupNode = popupElement;

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -161,7 +161,7 @@ function warningProps(props: SelectProps) {
 
   Object.entries(deprecatedProps).forEach(([deprecatedProp, newProp]) => {
     if (deprecatedProp in props) {
-      warning(false, `'${deprecatedProp}' is deprecated. Please use '${newProp}' instead.`);
+      warning(false, `\`${deprecatedProp}\` is deprecated. Please use \`${newProp}\` instead.`);
     }
   });
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -149,6 +149,28 @@ function warningProps(props: SelectProps) {
       );
     }
   }
+
+  // Deprecated API warnings
+  const deprecatedProps = {
+    dropdownClassName: 'popupClassName',
+    dropdownStyle: 'popupStyle',
+    dropdownAlign: 'popupAlign',
+    dropdownRender: 'popupRender',
+    dropdownMatchSelectWidth: 'popupMatchSelectWidth',
+  };
+
+  Object.entries(deprecatedProps).forEach(([deprecatedProp, newProp]) => {
+    if (deprecatedProp in props) {
+      warning(false, `'${deprecatedProp}' is deprecated. Please use '${newProp}' instead.`);
+    }
+  });
+
+  if ('onDropdownVisibleChange' in props) {
+    warning(
+      false,
+      '`onDropdownVisibleChange` is deprecated. Please use `onPopupVisibleChange` instead.',
+    );
+  }
 }
 
 // value in Select option should not be null

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -149,28 +149,6 @@ function warningProps(props: SelectProps) {
       );
     }
   }
-
-  // Deprecated API warnings
-  const deprecatedProps = {
-    dropdownClassName: 'popupClassName',
-    dropdownStyle: 'popupStyle',
-    dropdownAlign: 'popupAlign',
-    dropdownRender: 'popupRender',
-    dropdownMatchSelectWidth: 'popupMatchSelectWidth',
-  };
-
-  Object.entries(deprecatedProps).forEach(([deprecatedProp, newProp]) => {
-    if (deprecatedProp in props) {
-      warning(false, `\`${deprecatedProp}\` is deprecated. Please use \`${newProp}\` instead.`);
-    }
-  });
-
-  if ('onDropdownVisibleChange' in props) {
-    warning(
-      false,
-      '`onDropdownVisibleChange` is deprecated. Please use `onPopupVisibleChange` instead.',
-    );
-  }
 }
 
 // value in Select option should not be null

--- a/tests/Combobox.test.tsx
+++ b/tests/Combobox.test.tsx
@@ -455,16 +455,16 @@ describe('Select.Combobox', () => {
   // https://github.com/ant-design/ant-design/issues/16572
   it('close when enter press without active option', () => {
     jest.useFakeTimers();
-    const onDropdownVisibleChange = jest.fn();
+    const onPopupVisibleChange = jest.fn();
     const { container } = render(
-      <Select mode="combobox" open onDropdownVisibleChange={onDropdownVisibleChange}>
+      <Select mode="combobox" open onPopupVisibleChange={onPopupVisibleChange}>
         <Option value="One">One</Option>
         <Option value="Two">Two</Option>
       </Select>,
     );
     keyDown(container.querySelector('input')!, KeyCode.ENTER);
     jest.runAllTimers();
-    expect(onDropdownVisibleChange).toHaveBeenCalledWith(false);
+    expect(onPopupVisibleChange).toHaveBeenCalledWith(false);
     jest.useRealTimers();
   });
 

--- a/tests/Custom.test.tsx
+++ b/tests/Custom.test.tsx
@@ -15,15 +15,15 @@ describe('Select.Custom', () => {
   });
 
   it('getRawInputElement', () => {
-    const onDropdownVisibleChange = jest.fn();
+    const onPopupVisibleChange = jest.fn();
     const { container } = render(
       <Select
         getRawInputElement={() => <span className="custom" />}
-        onDropdownVisibleChange={onDropdownVisibleChange}
+        onPopupVisibleChange={onPopupVisibleChange}
       />,
     );
     fireEvent.click(container.querySelector('.custom'));
 
-    expect(onDropdownVisibleChange).toHaveBeenCalledWith(true);
+    expect(onPopupVisibleChange).toHaveBeenCalledWith(true);
   });
 });

--- a/tests/Popup.test.tsx
+++ b/tests/Popup.test.tsx
@@ -13,17 +13,17 @@ describe('Select.Popup', () => {
   injectRunAllTimers(jest);
 
   it('click popup should not trigger close', () => {
-    const onDropdownVisibleChange = jest.fn();
+    const onPopupVisibleChange = jest.fn();
     render(
       <Select
         open
         options={[{ value: 'bamboo' }]}
-        onDropdownVisibleChange={onDropdownVisibleChange}
+        onPopupVisibleChange={onPopupVisibleChange}
         getPopupContainer={() => document.body}
       />,
     );
 
     fireEvent.mouseDown(document.querySelector('.rc-select-dropdown'));
-    expect(onDropdownVisibleChange).not.toHaveBeenCalled();
+    expect(onPopupVisibleChange).not.toHaveBeenCalled();
   });
 });

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -315,7 +315,7 @@ describe('Select.Basic', () => {
     const { container } = render(
       <Select
         direction="rtl"
-        dropdownRender={(origin) => (
+        popupRender={(origin) => (
           <>
             <Hooker />
             {origin}
@@ -892,13 +892,13 @@ describe('Select.Basic', () => {
         open: true,
       };
 
-      public onDropdownVisibleChange = (open) => {
+      public onPopupVisibleChange = (open) => {
         this.setState({ open });
       };
 
       public render() {
         return (
-          <Select open={this.state.open} onDropdownVisibleChange={this.onDropdownVisibleChange}>
+          <Select open={this.state.open} onPopupVisibleChange={this.onPopupVisibleChange}>
             <Option value="1">1</Option>
           </Select>
         );
@@ -1323,7 +1323,7 @@ describe('Select.Basic', () => {
     const { container } = testingRender(
       <Select
         open
-        dropdownRender={(menu) => (
+        popupRender={(menu) => (
           <div>
             <div className="dropdown-custom-node">CUSTOM NODE</div>
             {menu}
@@ -1345,7 +1345,7 @@ describe('Select.Basic', () => {
     const { container } = testingRender(
       <Select
         onMouseDown={onMouseDown}
-        dropdownRender={(menu) => (
+        popupRender={(menu) => (
           <div>
             <div id="dropdown-custom-node" onClick={onChildClick}>
               CUSTOM NODE
@@ -1486,7 +1486,7 @@ describe('Select.Basic', () => {
           listItemHeight={10}
           listHeight={100}
           style={{ width: 1000 }}
-          dropdownMatchSelectWidth={false}
+          popupMatchSelectWidth={false}
           options={options}
         />,
       );
@@ -1517,7 +1517,7 @@ describe('Select.Basic', () => {
 
   it('dropdown should auto-adjust horizontally when dropdownMatchSelectWidth is false', () => {
     render(
-      <Select dropdownMatchSelectWidth={233}>
+      <Select popupMatchSelectWidth={233}>
         <Option value={0}>0</Option>
         <Option value={1}>1</Option>
       </Select>,
@@ -1992,7 +1992,7 @@ describe('Select.Basic', () => {
     const { container } = render(
       <Select
         options={[{ value: 903, label: 'Bamboo' }]}
-        dropdownRender={(node) => <Wrapper>{node}</Wrapper>}
+        popupRender={(node) => <Wrapper>{node}</Wrapper>}
         open
       />,
     );
@@ -2366,93 +2366,5 @@ describe('Select.Basic', () => {
     );
     expect(element[0]).not.toHaveClass('rc-select-item-option-disabled');
     expect(element[1]).toHaveClass('rc-select-item-option-disabled');
-  });
-});
-
-describe('Select.Deprecated APIs', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
-  beforeEach(() => {
-    resetWarned();
-  });
-
-  const deprecatedAPIs = {
-    dropdownClassName: 'popupClassName',
-    dropdownStyle: 'popupStyle',
-    dropdownAlign: 'popupAlign',
-    dropdownRender: 'popupRender',
-    dropdownMatchSelectWidth: 'popupMatchSelectWidth',
-    onDropdownVisibleChange: 'onPopupVisibleChange',
-  };
-
-  Object.entries(deprecatedAPIs).forEach(([deprecatedProp, newProp]) => {
-    it(`should warning if use deprecated API '${deprecatedProp}'`, () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      const props = {
-        [deprecatedProp]: deprecatedProp === 'dropdownRender' ? (menu) => menu : true,
-      };
-
-      render(
-        <Select {...props}>
-          <Option value="1">1</Option>
-        </Select>,
-      );
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        `Warning: \`${deprecatedProp}\` is deprecated. Please use \`${newProp}\` instead.`,
-      );
-
-      errorSpy.mockRestore();
-    });
-  });
-
-  it('should not warning if use new APIs', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    render(
-      <Select
-        popupClassName="test"
-        popupStyle={{ color: 'red' }}
-        popupAlign={{ offset: [0, 0] }}
-        popupRender={(menu) => menu}
-        popupMatchSelectWidth={100}
-        onPopupVisibleChange={() => {}}
-      >
-        <Option value="1">1</Option>
-      </Select>,
-    );
-
-    expect(errorSpy).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
-  });
-
-  it('should work with both old and new APIs', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    const { container } = render(
-      <Select dropdownMatchSelectWidth={100} popupMatchSelectWidth={200}>
-        <Option value="1">1</Option>
-      </Select>,
-    );
-
-    // Should use new API value
-    toggleOpen(container);
-    expect((container.querySelector('.rc-select-dropdown') as HTMLElement).style.width).toBe(
-      '200px',
-    );
-
-    // Should still show warning
-    expect(errorSpy).toHaveBeenCalledWith(
-      `Warning: \`dropdownMatchSelectWidth\` is deprecated. Please use \`popupMatchSelectWidth\` instead.`,
-    );
-
-    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
- ref https://github.com/ant-design/ant-design/issues/52115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重大变更**
	- 将下拉菜单（dropdown）相关属性和方法重命名为弹出层（popup）相关属性和方法
	- 移除了一些过时的属性，如 `multiple`、`tags`、`combobox` 等
	- 更新了 `Select` 组件的 API，提高了一致性和清晰度

- **属性变更**
	- `dropdownMatchSelectWidth` → `popupMatchSelectWidth`
	- `dropdownStyle` → `popupStyle`
	- `dropdownClassName` → `popupClassName`
	- `dropdownRender` → `popupRender`
	- `onDropdownVisibleChange` → `onPopupVisibleChange`

- **兼容性提示**
	- 建议开发者更新代码中的相关属性名称
	- 不再支持某些旧版本属性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->