### PR TITLE
fix: tagRender should not be called when value is empty

### DIFF
--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -188,6 +188,10 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
   };
 
   const renderRest = (omittedValues: DisplayValueType[]) => {
+    // https://github.com/ant-design/ant-design/issues/48930
+    if (!values.length) {
+      return null;
+    }
     const content =
       typeof maxTagPlaceholder === 'function'
         ? maxTagPlaceholder(omittedValues)

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -323,6 +323,20 @@ describe('Select.Tags', () => {
       });
     });
 
+    // https://github.com/ant-design/ant-design/issues/48930
+    it('should not call tagRender when value is empty', () => {
+      const tagRender = jest.fn();
+      render(
+        <Select
+          mode="tags"
+          value={[]}
+          tagRender={tagRender}
+          options={[{ value: 'light' }, { value: 'dark' }]}
+        />,
+      );
+      expect(tagRender).not.toHaveBeenCalled();
+    });
+
     it('disabled', () => {
       const tagRender = jest.fn();
       render(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 无新功能

- **Bug 修复**
	- 修复了在选择器中没有选中值时的渲染行为
	- 确保当值为空时不会调用标签渲染函数

- **测试**
	- 添加了针对空值情况的测试用例，提高了代码的健壮性

这些更改改进了组件的渲染逻辑和测试覆盖率，确保在处理空值时的正确行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->