### PR TITLE
fix: tagRender should not be called when value is empty for antd 5.x

### DIFF
--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -188,6 +188,10 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
   };
 
   const renderRest = (omittedValues: DisplayValueType[]) => {
+    // https://github.com/ant-design/ant-design/issues/48930
+    if (!values.length) {
+      return null;
+    }
     const content =
       typeof maxTagPlaceholder === 'function'
         ? maxTagPlaceholder(omittedValues)

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -323,6 +323,20 @@ describe('Select.Tags', () => {
       });
     });
 
+    // https://github.com/ant-design/ant-design/issues/48930
+    it('should not call tagRender when value is empty', () => {
+      const tagRender = jest.fn();
+      render(
+        <Select
+          mode="tags"
+          value={[]}
+          tagRender={tagRender}
+          options={[{ value: 'light' }, { value: 'dark' }]}
+        />,
+      );
+      expect(tagRender).not.toHaveBeenCalled();
+    });
+
     it('disabled', () => {
       const tagRender = jest.fn();
       render(


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/48930