### PR TITLE
fix: The Enter key lock cannot be released correctly when the custom input calls blur().

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -535,11 +535,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     }
 
     if (mergedOpen && (!isEnterKey || !keyLockRef.current)) {
+      // Lock the Enter key after it is pressed to avoid repeated triggering of the onChange event.
+      if (isEnterKey) {
+        keyLockRef.current = true;
+      }
       listRef.current?.onKeyDown(event, ...rest);
-    }
-
-    if (isEnterKey) {
-      keyLockRef.current = true;
     }
 
     onKeyDown?.(event, ...rest);
@@ -564,6 +564,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       type: 'remove',
       values: [val],
     });
+  };
+
+  const onSelectorBlur = () => {
+    // Unlock the Enter key after the selector blur; otherwise, the Enter key needs to be pressed twice to trigger the correct effect.
+    keyLockRef.current = false;
   };
 
   // ========================== Focus / Blur ==========================
@@ -813,6 +818,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
           onSearchSubmit={onInternalSearchSubmit}
           onRemove={onSelectorRemove}
           tokenWithEnter={tokenWithEnter}
+          onSelectorBlur={onSelectorBlur}
         />
       )}
     </SelectTrigger>

--- a/src/Selector/Input.tsx
+++ b/src/Selector/Input.tsx
@@ -25,6 +25,7 @@ interface InputProps {
   onMouseDown: React.MouseEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
   onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
   onPaste: React.ClipboardEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
+  onBlur: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
   onCompositionStart: React.CompositionEventHandler<
     HTMLInputElement | HTMLTextAreaElement | HTMLElement
   >;
@@ -52,6 +53,7 @@ const Input: React.ForwardRefRenderFunction<InputRef, InputProps> = (props, ref)
     onPaste,
     onCompositionStart,
     onCompositionEnd,
+    onBlur,
     open,
     attrs,
   } = props;
@@ -66,6 +68,7 @@ const Input: React.ForwardRefRenderFunction<InputRef, InputProps> = (props, ref)
     onMouseDown: onOriginMouseDown,
     onCompositionStart: onOriginCompositionStart,
     onCompositionEnd: onOriginCompositionEnd,
+    onBlur: onOriginBlur,
     style,
   } = originProps;
 
@@ -134,6 +137,12 @@ const Input: React.ForwardRefRenderFunction<InputRef, InputProps> = (props, ref)
       }
     },
     onPaste,
+    onBlur(event: React.FocusEvent<HTMLElement>) {
+      onBlur(event);
+      if (onOriginBlur) {
+        onOriginBlur(event);
+      }
+    },
   });
 
   return inputNode;

--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -72,6 +72,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     onInputMouseDown,
     onInputCompositionStart,
     onInputCompositionEnd,
+    onInputBlur,
   } = props;
 
   const measureRef = React.useRef<HTMLSpanElement>(null);
@@ -231,6 +232,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
         onPaste={onInputPaste}
         onCompositionStart={onInputCompositionStart}
         onCompositionEnd={onInputCompositionEnd}
+        onBlur={onInputBlur}
         tabIndex={tabIndex}
         attrs={pickAttrs(props, true)}
       />

--- a/src/Selector/SingleSelector.tsx
+++ b/src/Selector/SingleSelector.tsx
@@ -36,6 +36,7 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
     onInputPaste,
     onInputCompositionStart,
     onInputCompositionEnd,
+    onInputBlur,
     title,
   } = props;
 
@@ -100,6 +101,7 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
           onPaste={onInputPaste}
           onCompositionStart={onInputCompositionStart}
           onCompositionEnd={onInputCompositionEnd}
+          onBlur={onInputBlur}
           tabIndex={tabIndex}
           attrs={pickAttrs(props, true)}
           maxLength={combobox ? maxLength : undefined}

--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -44,6 +44,7 @@ export interface InnerSelectorProps {
   onInputPaste: React.ClipboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onInputCompositionStart: React.CompositionEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onInputCompositionEnd: React.CompositionEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onInputBlur: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 }
 
 export interface RefSelectorProps {
@@ -92,7 +93,8 @@ export interface SelectorProps {
   onSearchSubmit?: (searchText: string) => void;
   onRemove: (value: DisplayValueType) => void;
   onInputKeyDown?: React.KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-
+  // on selector blur
+  onSelectorBlur?: () => void;
   /**
    * @private get real dom for trigger align.
    * This may be removed after React provides replacement of `findDOMNode`
@@ -119,6 +121,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     onSearchSubmit,
     onToggleOpen,
     onInputKeyDown,
+    onSelectorBlur,
 
     domRef,
   } = props;
@@ -270,6 +273,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     onInputPaste,
     onInputCompositionStart,
     onInputCompositionEnd,
+    onInputBlur: onSelectorBlur,
   };
 
   const selectNode =

--- a/tests/utils/common.ts
+++ b/tests/utils/common.ts
@@ -117,3 +117,23 @@ export function keyUp(element: HTMLElement, keyCode: number) {
     fireEvent(element, event);
   });
 }
+
+/**
+ * Wait for a time delay. Will wait `advanceTime * times` ms.
+ *
+ * @param advanceTime Default 1000
+ * @param times Default 20
+ */
+export async function waitFakeTimer(advanceTime = 1000, times = 20) {
+  for (let i = 0; i < times; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+
+      if (advanceTime > 0) {
+        jest.advanceTimersByTime(advanceTime);
+      } else {
+        jest.runAllTimers();
+      }
+    });
+  }
+}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue
fix: [ant-design#52028](https://github.com/ant-design/ant-design/issues/52028)

### 💡 需求背景和解决方案
问题：
AutoComplete组件使用自定义Input，在onSelect事件中执行Input的blur()，会导致下次展开备选列表时无法用Enter选中

原因：
按下Enter键  -->  触发onSelect -->  在onSelect里面执行blur()  -->  在onKeyDown里面把keyLockRef.current设置为true  -->  正常是应该在onKeyUp里面释放锁的，但是因为执行了blur()，导致keyup事件不会触发，所以keyLockRef为true

于是在下次点击enter的时候，由于keyLockRef为true，就不会触发onSelect事件，反而可以正常触发keyup了，在onKeyUp里面释放了keyLockRef，也就是问题描述里的第二次开始需要点击两次Enter键才可以正常用

解决方案：
优化keyLockRef设置为true的时机，在触发onSelect之前设置为true，并给Selector添加一个onBlur的事件处理函数，在onBlur时主动释放keyLockRef
### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |fix: The Enter key lock cannot be released correctly when the custom input calls blur().([ant-design#52028](https://github.com/ant-design/ant-design/issues/52028))|
| 🇨🇳 中文 |fix: 在onSelect中触发自定义Input的blur()时，没有正确释放回车键的keyLockRef。([ant-design#52028](https://github.com/ant-design/ant-design/issues/52028))|

The Enter key lock cannot be released correctly when the custom input calls blur().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

- **新功能**
  - 增强了选择器组件的键盘交互逻辑
  - 改进了输入框失焦（blur）事件处理机制

- **测试**
  - 新增了针对选择器组件的测试用例
  - 优化了测试工具函数，提高测试可靠性

- **改进**
  - 优化了Enter键的触发和锁定行为
  - 增加了对自定义输入元素的支持
  - 完善了输入框焦点管理机制

这些更改旨在提升组件的用户交互体验和稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->