### PR TITLE
fix: The Enter key lock cannot be released correctly when the custom input calls blur()

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -537,11 +537,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     }
 
     if (mergedOpen && (!isEnterKey || !keyLockRef.current)) {
+      // Lock the Enter key after it is pressed to avoid repeated triggering of the onChange event.
+      if (isEnterKey) {
+        keyLockRef.current = true;
+      }
       listRef.current?.onKeyDown(event, ...rest);
-    }
-
-    if (isEnterKey) {
-      keyLockRef.current = true;
     }
 
     onKeyDown?.(event, ...rest);
@@ -566,6 +566,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       type: 'remove',
       values: [val],
     });
+  };
+
+  const onInputBlur = () => {
+    // Unlock the Enter key after the input blur; otherwise, the Enter key needs to be pressed twice to trigger the correct effect.
+    keyLockRef.current = false;
   };
 
   // ========================== Focus / Blur ==========================
@@ -815,6 +820,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
           onSearchSubmit={onInternalSearchSubmit}
           onRemove={onSelectorRemove}
           tokenWithEnter={tokenWithEnter}
+          onInputBlur={onInputBlur}
         />
       )}
     </SelectTrigger>

--- a/src/Selector/Input.tsx
+++ b/src/Selector/Input.tsx
@@ -25,6 +25,7 @@ interface InputProps {
   onMouseDown: React.MouseEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
   onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
   onPaste: React.ClipboardEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
+  onBlur: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLElement>;
   onCompositionStart: React.CompositionEventHandler<
     HTMLInputElement | HTMLTextAreaElement | HTMLElement
   >;
@@ -52,6 +53,7 @@ const Input: React.ForwardRefRenderFunction<InputRef, InputProps> = (props, ref)
     onPaste,
     onCompositionStart,
     onCompositionEnd,
+    onBlur,
     open,
     attrs,
   } = props;
@@ -66,6 +68,7 @@ const Input: React.ForwardRefRenderFunction<InputRef, InputProps> = (props, ref)
     onMouseDown: onOriginMouseDown,
     onCompositionStart: onOriginCompositionStart,
     onCompositionEnd: onOriginCompositionEnd,
+    onBlur: onOriginBlur,
     style,
   } = originProps;
 
@@ -134,6 +137,12 @@ const Input: React.ForwardRefRenderFunction<InputRef, InputProps> = (props, ref)
       }
     },
     onPaste,
+    onBlur(event: React.FocusEvent<HTMLElement>) {
+      onBlur(event);
+      if (onOriginBlur) {
+        onOriginBlur(event);
+      }
+    },
   });
 
   return inputNode;

--- a/src/Selector/MultipleSelector.tsx
+++ b/src/Selector/MultipleSelector.tsx
@@ -72,6 +72,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
     onInputMouseDown,
     onInputCompositionStart,
     onInputCompositionEnd,
+    onInputBlur,
   } = props;
 
   const measureRef = React.useRef<HTMLSpanElement>(null);
@@ -231,6 +232,7 @@ const SelectSelector: React.FC<SelectorProps> = (props) => {
         onPaste={onInputPaste}
         onCompositionStart={onInputCompositionStart}
         onCompositionEnd={onInputCompositionEnd}
+        onBlur={onInputBlur}
         tabIndex={tabIndex}
         attrs={pickAttrs(props, true)}
       />

--- a/src/Selector/SingleSelector.tsx
+++ b/src/Selector/SingleSelector.tsx
@@ -36,6 +36,7 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
     onInputPaste,
     onInputCompositionStart,
     onInputCompositionEnd,
+    onInputBlur,
     title,
   } = props;
 
@@ -100,6 +101,7 @@ const SingleSelector: React.FC<SelectorProps> = (props) => {
           onPaste={onInputPaste}
           onCompositionStart={onInputCompositionStart}
           onCompositionEnd={onInputCompositionEnd}
+          onBlur={onInputBlur}
           tabIndex={tabIndex}
           attrs={pickAttrs(props, true)}
           maxLength={combobox ? maxLength : undefined}

--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -44,6 +44,7 @@ export interface InnerSelectorProps {
   onInputPaste: React.ClipboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onInputCompositionStart: React.CompositionEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onInputCompositionEnd: React.CompositionEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onInputBlur: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 }
 
 export interface RefSelectorProps {
@@ -92,7 +93,8 @@ export interface SelectorProps {
   onSearchSubmit?: (searchText: string) => void;
   onRemove: (value: DisplayValueType) => void;
   onInputKeyDown?: React.KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
-
+  // on inner input blur
+  onInputBlur?: () => void;
   /**
    * @private get real dom for trigger align.
    * This may be removed after React provides replacement of `findDOMNode`
@@ -119,6 +121,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     onSearchSubmit,
     onToggleOpen,
     onInputKeyDown,
+    onInputBlur,
 
     domRef,
   } = props;
@@ -270,6 +273,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     onInputPaste,
     onInputCompositionStart,
     onInputCompositionEnd,
+    onInputBlur,
   };
 
   const selectNode =

--- a/tests/utils/common.ts
+++ b/tests/utils/common.ts
@@ -117,3 +117,21 @@ export function keyUp(element: HTMLElement, keyCode: number) {
     fireEvent(element, event);
   });
 }
+
+/**
+ * Wait for a time delay. Will wait `advanceTime * times` ms.
+ *
+ * @param advanceTime Default 1000
+ * @param times Default 20
+ */
+export async function waitFakeTimer(advanceTime = 1000, times = 20) {
+  for (let i = 0; i < times; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+
+      if (advanceTime > 0) {
+        jest.advanceTimersByTime(advanceTime);
+      }
+    });
+  }
+}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

ref https://github.com/ant-design/ant-design/issues/52028

### 💡 需求背景和解决方案
问题：
AutoComplete组件使用自定义Input，在onSelect事件中执行Input的blur()，会导致下次展开备选列表时无法用Enter选中

原因：
按下Enter键  -->  触发onSelect -->  在onSelect里面执行blur()  -->  在onKeyDown里面把keyLockRef.current设置为true  -->  正常是应该在onKeyUp里面释放锁的，但是因为执行了blur()，导致keyup事件不会触发，所以keyLockRef为true

于是在下次点击enter的时候，由于keyLockRef为true，就不会触发onSelect事件，反而可以正常触发keyup了，在onKeyUp里面释放了keyLockRef，也就是问题描述里的第二次开始需要点击两次Enter键才可以正常用

解决方案：
优化keyLockRef设置为true的时机，在触发onSelect之前设置为true，并给Selector内部的input添加一个onBlur的事件处理函数，在onBlur时主动释放keyLockRef
### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |fix: The Enter key lock cannot be released correctly when the custom input calls blur().([ant-design#52028](https://github.com/ant-design/ant-design/issues/52028))|
| 🇨🇳 中文 |fix: 在onSelect中触发自定义Input的blur()时，没有正确释放回车键的keyLockRef。([ant-design#52028](https://github.com/ant-design/ant-design/issues/52028))|

The Enter key lock cannot be released correctly when the custom input calls blur().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 为选择器组件添加了输入和选择器的模糊事件处理
	- 改进了回车键的交互控制机制

- **测试**
	- 新增了针对自定义输入元素和回车键锁定行为的测试用例
	- 添加了用于测试计时器的实用函数
<!-- end of auto-generated comment: release notes by coderabbit.ai -->