### PR TITLE
fix: add `undefined` to optional `className` properties (fixes #1143)

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -129,7 +129,7 @@ export type BaseSelectPropsWithoutPrivate = Omit<BaseSelectProps, keyof BaseSele
 
 export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttributes {
   // Style
-  className: string | undefined;
+  className?: string | undefined;
   style?: React.CSSProperties;
   classNames?: Partial<Record<BaseSelectSemanticName, string>>;
   styles?: Partial<Record<BaseSelectSemanticName, React.CSSProperties>>;
@@ -195,7 +195,7 @@ export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttri
   transitionName?: string;
 
   popupStyle?: React.CSSProperties;
-  popupClassName?: string;
+  popupClassName?: string | undefined;
   popupMatchSelectWidth?: boolean | number;
   popupRender?: (menu: React.ReactElement) => React.ReactElement;
   popupAlign?: AlignType;

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -129,7 +129,7 @@ export type BaseSelectPropsWithoutPrivate = Omit<BaseSelectProps, keyof BaseSele
 
 export interface BaseSelectProps extends BaseSelectPrivateProps, React.AriaAttributes {
   // Style
-  className?: string;
+  className: string | undefined;
   style?: React.CSSProperties;
   classNames?: Partial<Record<BaseSelectSemanticName, string>>;
   styles?: Partial<Record<BaseSelectSemanticName, React.CSSProperties>>;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -90,7 +90,7 @@ export interface FieldNames {
 
 export interface BaseOptionType {
   disabled?: boolean;
-  className?: string;
+  className?: string | undefined;
   title?: string;
   [name: string]: any;
 }


### PR DESCRIPTION
With a reference to https://www.github.com/DefinitelyTyped/DefinitelyTyped/pull/54352, this PR addresses a TypeScript error that occurs when using rc-select with CSS Modules in a Vite project with `exactOptionalPropertyTypes: true` enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
	- 此次更改显式地在 `BaseSelectProps` 接口和 `BaseOptionType` 接口中将 `className` 和 `popupClassName` 两个可选字符串属性的类型声明从隐式的可选（`string` 或未声明）改为显式包含 `undefined`（`string | undefined`）。这些修改仅调整了类型注解的明确性，不影响运行时行为或逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->