### PR TITLE
fix: Select dropdown should scroll to the option with the closest prefix to the searched value.

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -157,7 +157,10 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
     const timeoutId = setTimeout(() => {
       if (!multiple && open && rawValues.size === 1) {
         const value: RawValueType = Array.from(rawValues)[0];
-        const index = memoFlattenOptions.findIndex(({ data }) => data.value === value);
+        // Scroll to the option closest to the searchValue if searching.
+        const index = memoFlattenOptions.findIndex(({ data }) =>
+          searchValue ? String(data.value).startsWith(searchValue) : data.value === value,
+        );
 
         if (index !== -1) {
           setActive(index);


### PR DESCRIPTION
Should fix : https://github.com/ant-design/ant-design/issues/53752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 改进了单选模式下选项列表打开时的选中项定位逻辑，支持根据当前搜索输入优先定位到首个匹配项，提升搜索和选择体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->