### PR TITLE
fix:Select with maxCount limit does not allow removal of selected opt…

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -226,7 +226,11 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
         case KeyCode.ENTER: {
           // value
           const item = memoFlattenOptions[activeIndex];
-          if (item && !item?.data?.disabled && !overMaxCount) {
+          if (!item || item.data.disabled) {
+            return onSelectValue(undefined);
+          }
+
+          if (!overMaxCount || rawValues.has(item.value)) {
             onSelectValue(item.value);
           } else {
             onSelectValue(undefined);

--- a/tests/OptionList.test.tsx
+++ b/tests/OptionList.test.tsx
@@ -462,6 +462,54 @@ describe('OptionList', () => {
     expect(onActiveValue).not.toHaveBeenCalledWith('3', expect.anything(), expect.anything());
   });
 
+  it('should deselect a selected option when Enter is pressed and maxCount is reached', () => {
+    const onSelect = jest.fn();
+    const toggleOpen = jest.fn();
+    const listRef = React.createRef<RefOptionListProps>();
+
+    // Initial selected values: '1' and '2'
+    const initialValues = new Set(['1', '2']);
+
+    render(
+      generateList({
+        multiple: true,
+        maxCount: 2,
+        options: [
+          { value: '1', label: '1' },
+          { value: '2', label: '2' },
+          { value: '3', label: '3' },
+        ],
+        values: initialValues,
+        onSelect,
+        toggleOpen,
+        ref: listRef,
+      }),
+    );
+
+    // Verify initial selection state
+    expect(initialValues.has('1')).toBe(true); // 1 is selected
+    expect(initialValues.has('2')).toBe(true); // 2 is selected
+    expect(initialValues.has('3')).toBe(false); // 3 is not selected
+
+    act(() => {
+      toggleOpen(true);
+    });
+
+    act(() => {
+      listRef.current.onKeyDown({ which: KeyCode.ENTER } as any);
+    });
+
+    // Verify that onSelect was called to deselect '1'
+    expect(onSelect).toHaveBeenCalledWith('1', expect.objectContaining({ selected: false }));
+
+    // Verify that onSelect was NOT called for '2' or '3'
+    expect(onSelect).not.toHaveBeenCalledWith('2', expect.anything());
+    expect(onSelect).not.toHaveBeenCalledWith('3', expect.anything());
+
+    // Verify only one call was made (for deselecting '1')
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
   describe('List.ScrollBar', () => {
     let mockElement;
     let boundingRect = {


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/53637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **优化**
  - 改进了使用回车键选择选项时的逻辑，提升了对禁用或缺失选项的处理体验，并优化了最大选择数情况下的交互反馈。
- **测试**
  - 新增测试覆盖在达到最大选择数时按回车键的行为，确保选项的正确取消选择和回调触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->