### PR TITLE
refactor: remove getTriggerDOMNode usage

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -4,6 +4,7 @@ import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
 import isMobile from '@rc-component/util/lib/isMobile';
 import { useComposeRef } from '@rc-component/util/lib/ref';
+import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 import type { ScrollConfig, ScrollTo } from 'rc-virtual-list/lib/List';
 import * as React from 'react';
 import { useAllowClear } from '../hooks/useAllowClear';
@@ -330,11 +331,11 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
 
   // ============================== Refs ==============================
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const selectorDomRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<RefTriggerProps>(null);
   const selectorRef = React.useRef<RefSelectorProps>(null);
   const listRef = React.useRef<RefOptionListProps>(null);
   const blurRef = React.useRef<boolean>(false);
+  const customDomRef = React.useRef<HTMLElement>(null);
 
   /** Used for component focused management */
   const [mockFocused, setMockFocused, cancelSetMockFocused] = useDelayReset();
@@ -344,7 +345,10 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     focus: selectorRef.current?.focus,
     blur: selectorRef.current?.blur,
     scrollTo: (arg) => listRef.current?.scrollTo(arg),
-    nativeElement: containerRef.current || selectorDomRef.current,
+    nativeElement:
+      containerRef.current ||
+      selectorRef.current?.nativeElement ||
+      (getDOM(customDomRef.current) as HTMLElement),
   }));
 
   // ========================== Search Value ==========================
@@ -368,7 +372,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     typeof getRawInputElement === 'function' && getRawInputElement();
 
   const customizeRawInputRef = useComposeRef<HTMLElement>(
-    selectorDomRef,
+    customDomRef,
     customizeRawInputElement?.props?.ref,
   );
 
@@ -808,12 +812,6 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       builtinPlacements={builtinPlacements}
       getPopupContainer={getPopupContainer}
       empty={emptyOptions}
-      getTriggerDOMNode={(node) =>
-        // TODO: This is workaround and should be removed in `rc-select`
-        // And use new standard `nativeElement` for ref.
-        // But we should update `rc-resize-observer` first.
-        selectorDomRef.current || node
-      }
       onPopupVisibleChange={onTriggerVisibleChange}
       onPopupMouseEnter={onPopupMouseEnter}
     >
@@ -826,7 +824,6 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
           {...props}
           prefixClassName={classNames?.prefix}
           prefixStyle={styles?.prefix}
-          domRef={selectorDomRef}
           prefixCls={prefixCls}
           inputElement={customizeInputElement}
           ref={selectorRef}

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -73,7 +73,6 @@ export interface SelectTriggerProps {
   popupAlign: AlignType;
   empty: boolean;
 
-  getTriggerDOMNode: (node: HTMLElement) => HTMLElement;
   onPopupVisibleChange?: (visible: boolean) => void;
 
   onPopupMouseEnter: () => void;
@@ -101,7 +100,6 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
     popupAlign,
     getPopupContainer,
     empty,
-    getTriggerDOMNode,
     onPopupVisibleChange,
     onPopupMouseEnter,
     ...restProps
@@ -174,7 +172,6 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
         [`${popupPrefixCls}-empty`]: empty,
       })}
       popupStyle={mergedPopupStyle}
-      getTriggerDOMNode={getTriggerDOMNode}
       onPopupVisibleChange={onPopupVisibleChange}
     >
       {children}

--- a/src/Selector/index.tsx
+++ b/src/Selector/index.tsx
@@ -52,6 +52,7 @@ export interface RefSelectorProps {
   focus: (options?: FocusOptions) => void;
   blur: () => void;
   scrollTo?: ScrollTo;
+  nativeElement: HTMLDivElement;
 }
 
 export interface SelectorProps {
@@ -98,11 +99,6 @@ export interface SelectorProps {
   onInputKeyDown?: React.KeyboardEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   // on inner input blur
   onInputBlur?: () => void;
-  /**
-   * @private get real dom for trigger align.
-   * This may be removed after React provides replacement of `findDOMNode`
-   */
-  domRef: React.Ref<HTMLDivElement>;
 }
 
 const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> = (props, ref) => {
@@ -127,11 +123,11 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     onToggleOpen,
     onInputKeyDown,
     onInputBlur,
-
-    domRef,
   } = props;
 
   // ======================= Ref =======================
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   React.useImperativeHandle(ref, () => ({
     focus: (options) => {
       inputRef.current.focus(options);
@@ -139,6 +135,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
     blur: () => {
       inputRef.current.blur();
     },
+    nativeElement: containerRef.current,
   }));
 
   // ====================== Input ======================
@@ -290,7 +287,7 @@ const Selector: React.ForwardRefRenderFunction<RefSelectorProps, SelectorProps> 
 
   return (
     <div
-      ref={domRef}
+      ref={containerRef}
       className={`${prefixCls}-selector`}
       onClick={onClick}
       onMouseDown={onMouseDown}


### PR DESCRIPTION
### 背景

在 https://github.com/ant-design/ant-design/issues/50443  中提到 Tooltip 的渲染性能问题，经过排查在 dev 模式下性能主要损耗在于 `ReactElement` 创建上（prop 模式下不开启 react dev tool 其实并没有那么卡）。不过开发者的体验也是有提升空间的。

### 为什么改 Select？

`rc-trigger` 有一个特殊方法 `getTriggerDOMNode` 允许自定义寻找 DOM 节点的逻辑而不是直接 ref 获取子元素。这对于 HOC 后提供的 ref 不是 DOM 的情况很有帮助，而在新的 ref 规范中，我们认为 `ref.nativeElement` 可以标识 DOM 节点。因而可以借此减少 `getTriggerDOMNode` 的调用，从而最终清理后在上述 issue 中减少 `createElement` 的数量。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 简化和统一了下拉选择组件的 DOM 引用管理方式，移除了部分冗余引用，提升了代码一致性和可维护性。  
  - 对外暴露的接口未发生变更，组件的使用方式保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->