### PR TITLE
fix: improve useDelayReset logic and add focus test for Select

### DIFF
--- a/src/hooks/useDelayReset.ts
+++ b/src/hooks/useDelayReset.ts
@@ -33,9 +33,7 @@ export default function useDelayReset(
       // false 值延迟设置
       delayRef.current = window.setTimeout(() => {
         setBool(false);
-        if (callback) {
-          callback();
-        }
+        callback?.();
       }, timeout);
     }
   };

--- a/src/hooks/useDelayReset.ts
+++ b/src/hooks/useDelayReset.ts
@@ -26,9 +26,7 @@ export default function useDelayReset(
     if (value === true) {
       // true 值立即设置
       setBool(true);
-      if (callback) {
-        callback();
-      }
+      callback?.();
     } else {
       // false 值延迟设置
       delayRef.current = window.setTimeout(() => {

--- a/src/hooks/useDelayReset.ts
+++ b/src/hooks/useDelayReset.ts
@@ -14,17 +14,30 @@ export default function useDelayReset(
     window.clearTimeout(delayRef.current);
   };
 
-  React.useEffect(() => cancelLatest, []);
+  React.useEffect(() => {
+    return () => {
+      cancelLatest();
+    };
+  }, []);
 
-  const delaySetBool = (value: boolean, callback: () => void) => {
+  const delaySetBool = (value: boolean, callback?: () => void) => {
     cancelLatest();
 
-    delayRef.current = window.setTimeout(() => {
-      setBool(value);
+    if (value === true) {
+      // true 值立即设置
+      setBool(true);
       if (callback) {
         callback();
       }
-    }, timeout);
+    } else {
+      // false 值延迟设置
+      delayRef.current = window.setTimeout(() => {
+        setBool(false);
+        if (callback) {
+          callback();
+        }
+      }, timeout);
+    }
   };
 
   return [bool, delaySetBool, cancelLatest];

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -10,7 +10,7 @@ import KeyCode from '@rc-component/util/lib/KeyCode';
 import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import { resetWarned } from '@rc-component/util/lib/warning';
 import type { ScrollConfig } from 'rc-virtual-list/lib/List';
-import React from 'react';
+import React, { StrictMode } from 'react';
 import type { SelectProps } from '../src';
 import Select, { OptGroup, Option, useBaseProps } from '../src';
 import BaseSelect from '../src/BaseSelect';
@@ -2669,6 +2669,18 @@ describe('Select.Basic', () => {
       } else {
         expect(inputNode).toHaveAttribute('readonly');
       }
+    });
+
+    it('should has focus class when focus', () => {
+      const { container } = render(
+        <StrictMode>
+          <Select options={[{ value: 'a', label: '1' }]} />
+        </StrictMode>,
+      );
+      const inputNode = container.querySelector('input');
+      fireEvent.focus(inputNode);
+      const select = container.querySelector('.rc-select');
+      expect(select).toHaveClass('rc-select-focused');
     });
   });
 });


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [https://github.com/ant-design/ant-design/issues/54546](https://github.com/ant-design/ant-design/issues/54546)

### 💡 Background and Solution
Select component doesn't show focus style when calling focus() after enabling StrictMode
In StrictMode, useEffect executes multiple times. The delaySetBool method distinguishes the value - if it's false, it enters the delay branch.

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Select component style error after calling focus in StrictMode |
| 🇨🇳 Chinese | 修复 StrictMode 下调用 focus 后 Select 样式错误 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **修复问题**
  * 修正了布尔状态延迟设置的逻辑，现在设置为 true 时会立即生效并可选回调，设置为 false 时则延迟处理。

* **测试**
  * 新增了 Select 组件在受控聚焦状态下的样式测试，确保输入框聚焦时样式正确应用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->