### PR TITLE
refactor: Upgrade utils and replace useMergedState

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@rc-component/trigger": "^3.0.0",
     "@rc-component/motion": "^1.1.4",
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.3.0",
     "classnames": "2.x",
     "rc-overflow": "^1.4.0",
     "rc-virtual-list": "^3.5.2"

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -1,7 +1,7 @@
 import type { AlignType, BuildInPlacements } from '@rc-component/trigger/lib/interface';
 import cls from 'classnames';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import isMobile from '@rc-component/util/lib/isMobile';
 import { useComposeRef } from '@rc-component/util/lib/ref';
 import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
@@ -383,10 +383,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     setRendered(true);
   }, []);
 
-  const [innerOpen, setInnerOpen] = useMergedState<boolean>(false, {
-    defaultValue: defaultOpen,
-    value: open,
-  });
+  const [innerOpen, setInnerOpen] = useControlledState<boolean>(defaultOpen || false, open);
 
   let mergedOpen = rendered ? innerOpen : false;
 

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -272,7 +272,8 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
     );
 
     // =========================== Search ===========================
-    const [mergedSearchValue, setSearchValue] = useControlledState('', searchValue);
+    const [internalSearchValue, setSearchValue] = useControlledState('', searchValue);
+    const mergedSearchValue = internalSearchValue || '';
 
     // =========================== Option ===========================
     const parsedOptions = useOptions(

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -29,7 +29,7 @@
  * - `combobox` mode not support `optionLabelProp`
  */
 
-import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import warning from '@rc-component/util/lib/warning';
 import * as React from 'react';
 import type {
@@ -272,10 +272,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
     );
 
     // =========================== Search ===========================
-    const [mergedSearchValue, setSearchValue] = useMergedState('', {
-      value: searchValue,
-      postState: (search) => search || '',
-    });
+    const [mergedSearchValue, setSearchValue] = useControlledState('', searchValue);
 
     // =========================== Option ===========================
     const parsedOptions = useOptions(
@@ -343,9 +340,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
     );
 
     // =========================== Values ===========================
-    const [internalValue, setInternalValue] = useMergedState(defaultValue, {
-      value,
-    });
+    const [internalValue, setInternalValue] = useControlledState(defaultValue, value);
 
     // Merged value with LabelValueType
     const rawLabeledValues = React.useMemo(() => {


### PR DESCRIPTION
关联issue：https://github.com/ant-design/ant-design/issues/54854
替换 useMergedState 为 useControlledState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新特性
  - 无

- 重构
  - 将选择组件的内部状态管理由合并状态切换为受控/非受控模式，覆盖展开状态、搜索值与内部值；对外行为和公共 API 不变。

- 杂务
  - 更新依赖 @rc-component/util 至 ^1.3.0。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->