### PR TITLE
feat: support `role` prop in RcSelect for accessibility

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -179,6 +179,12 @@ export interface SelectProps<ValueType = any, OptionType extends BaseOptionType 
   onChange?: (value: ValueType, option?: OptionType | OptionType[]) => void;
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+
+  // >>> Accessibility
+  // https://github.com/ant-design/ant-design/issues/46030
+  // https://github.com/ant-design/ant-design/issues/53713
+  // https://github.com/ant-design/ant-design/pull/55185#discussion_r2389642896
+  role?: string;
 }
 
 function isRawValue(value: DraftValueType): value is RawValueType {


### PR DESCRIPTION
## Motivation
Currently, `<RcSelect />` does not accept the `role` prop as an input, which prevents developers from explicitly defining accessibility roles (e.g., `role="combobox"`).  
This causes accessibility checkers to report errors such as `ARIA attribute is not allowed: aria-required="true"` because the element lacks a supported role.

## What I changed
- Added `role?: string` to `SelectProps` type.
- Passed the `role` prop down to the root element of RcSelect.

## Impact
Developers can now explicitly set `role="combobox"` (or other ARIA-supported roles) on `<Select />`, ensuring proper accessibility compliance.

## Related
- Improves integration with libraries like Ant Design where `aria-required` is used on `<Select />`.
                                  