### PR TITLE
fix: not prevent when child

### DIFF
--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -171,7 +171,8 @@ export default React.forwardRef<SelectInputRef, SelectInputProps>(function Selec
   // ====================== Open ======================
   const onInternalMouseDown: SelectInputProps['onMouseDown'] = useEvent((event) => {
     if (!disabled) {
-      if (event.target !== getDOM(inputRef.current)) {
+      const inputDOM = getDOM(inputRef.current);
+      if (inputDOM && event.target !== inputDOM && !inputDOM.contains(event.target as Node)) {
         event.preventDefault();
       }
 

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import Select from '../src';
 import { injectRunAllTimers } from './utils/common';
@@ -21,5 +21,28 @@ describe('Select.Components', () => {
     );
 
     expect(container.querySelector('textarea')?.getAttribute('placeholder')).toBe('test');
+  });
+
+  it('should not preventDefault when customize input contains input', () => {
+    const preventDefault = jest.fn();
+    const { container } = render(
+      <Select
+        mode="combobox"
+        getInputElement={() => (
+          <div>
+            <textarea />
+          </div>
+        )}
+      />,
+    );
+
+    const textareaEle = container.querySelector('textarea');
+
+    // Create mouseDown event on the selector element
+    const mouseDownEvent = createEvent.mouseDown(textareaEle);
+    mouseDownEvent.preventDefault = preventDefault;
+    fireEvent(textareaEle, mouseDownEvent);
+
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/55924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了输入框组件的点击事件处理，确保在输入框内部元素上的点击不会触发意外的行为。

* **测试**
  * 添加了新的测试用例以验证输入框内部的事件处理逻辑。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->