### PR TITLE
fix: use only the attributes that are already defined

### DIFF
--- a/src/SelectInput/Content/SingleContent.tsx
+++ b/src/SelectInput/Content/SingleContent.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
+import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import Input from '../Input';
 import { useSelectInputContext } from '../context';
 import useBaseProps from '../../hooks/useBaseProps';
@@ -41,10 +42,12 @@ const SingleContent = React.forwardRef<HTMLInputElement, SharedContentProps>(
       if (displayValue && selectContext?.flattenOptions) {
         const option = selectContext.flattenOptions.find((opt) => opt.value === displayValue.value);
         if (option?.data) {
-          const { className, style } = option.data;
+          const { label, value, className, style, key, ...rest } = option.data;
+          const attrs = pickAttrs(rest);
 
           restProps = {
             ...restProps,
+            ...attrs,
             title: getTitle(option.data),
             className: clsx(restProps.className, className),
             style: { ...restProps.style, ...style },


### PR DESCRIPTION
# 🤔 This is a ...

- [ ] 🆕 New feature  
- [x] 🐞 Bug fix  
- [ ] 📝 Site / documentation improvement  
- [ ] 📽️ Demo improvement  
- [ ] 💄 Component style improvement  
- [ ] 🤖 TypeScript definition improvement  
- [ ] 📦 Bundle size optimization  
- [ ] ⚡️ Performance optimization  
- [ ] ⭐️ Feature enhancement  
- [ ] 🌐 Internationalization  
- [ ] 🛠 Refactoring  
- [ ] 🎨 Code style optimization  
- [ ] ✅ Test Case  
- [ ] 🔀 Branch merge  
- [ ] ⏩ Workflow  
- [ ] ⌨️ Accessibility improvement  
- [ ] ❓ Other (about what?)

---

## 🔗 Related Issues

https://github.com/ant-design/ant-design/issues/55877

---

## 💡 Background and Solution

Irrelevant attributes are also added to the div, causing React to show warnings in development mode，
This change only uses already defined attributes; all other attributes are ignored

---

## 📝 Change Log

| Language | Changelog |
|----------|-----------|
| 🇺🇸 English | only the attributes defined by Option are used, all other attributes are ignored |
| 🇨🇳 Chinese | 只使用 Option 定义的属性，其他属性忽略 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了选项额外数据的处理：渲染选项内容时仅提取并合并允许的属性，避免将非必要字段传播到组件属性中，确保 title、className、style 等关键属性被正确应用。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->