### PR TITLE
fix: mouseDown on the hidden element should not trigger close

### DIFF
--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -172,6 +172,12 @@ export default React.forwardRef<SelectInputRef, SelectInputProps>(function Selec
   // ====================== Open ======================
   const onInternalMouseDown: SelectInputProps['onMouseDown'] = useEvent((event) => {
     if (!disabled) {
+      // https://github.com/ant-design/ant-design/issues/56002
+      // Tell `useSelectTriggerControl` to ignore this event
+      // When icon is dynamic render, the parentNode will miss
+      // so we need to mark the event directly
+      (event.nativeEvent as any)._ignore_global_close = true;
+
       const inputDOM = getDOM(inputRef.current);
       if (inputDOM && event.target !== inputDOM && !inputDOM.contains(event.target as Node)) {
         event.preventDefault();

--- a/src/hooks/useSelectTriggerControl.ts
+++ b/src/hooks/useSelectTriggerControl.ts
@@ -21,6 +21,8 @@ export default function useSelectTriggerControl(
 
     if (
       open &&
+      // Marked by SelectInput mouseDown event
+      !(event as any)._ignore_global_close &&
       elements()
         .filter((element) => element)
         .every((element) => !element.contains(target) && element !== target)

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -389,6 +389,46 @@ describe('Select.Basic', () => {
     expect(container.querySelector('input').getAttribute('readonly')).toBeFalsy();
   });
 
+  it('dynamic change icon should not trigger close', () => {
+    const Demo = () => {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <Select
+          open={open}
+          onPopupVisibleChange={setOpen}
+          showSearch
+          suffix={
+            open ? (
+              <span className="bamboo" key="bamboo" />
+            ) : (
+              <span className="little" key="little" />
+            )
+          }
+        />
+      );
+    };
+
+    const { container } = render(<Demo />);
+    const suffix = container.querySelector('.little');
+
+    const mouseDownEvent = createEvent.mouseDown(suffix);
+
+    // First click on the element and re-render to remove the node
+    fireEvent(suffix, mouseDownEvent);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // Then popup to the window event (jsdom can not mock this. so we just fire directly)
+    fireEvent(window, mouseDownEvent);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expectOpen(container);
+  });
+
   it('should keep dropdown open when clicking inside popup to prevent accidental close', async () => {
     const { container } = render(
       <Select


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/56002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **问题修复**
  * 修复了动态改变 Select 下拉框后缀图标时导致下拉框意外关闭的问题。现在在修改后缀内容时，下拉框状态能够正确保持。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->