### PR TITLE
feat: add disableAutoScroll prop to control auto-scrolling behavior in the select component

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ export default () => (
 | dropdownRender | render custom dropdown menu | (menu: React.Node) => ReactNode | - |
 | loading | show loading icon in arrow | boolean | false |
 | virtual | Disable virtual scroll | boolean | true |
+| disableAutoScroll | Disable auto scroll to selected option | boolean | false |
 | direction | direction of dropdown | 'ltr' \| 'rtl' | 'ltr' |
 | optionRender | Custom rendering options | (oriOption: FlattenOptionData\<BaseOptionType\> , info: { index: number }) => React.ReactNode | - |
 | labelRender  | Custom rendering label   |  (props: LabelInValueType) => React.ReactNode   | - |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ export default () => (
 | dropdownRender | render custom dropdown menu | (menu: React.Node) => ReactNode | - |
 | loading | show loading icon in arrow | boolean | false |
 | virtual | Disable virtual scroll | boolean | true |
-| disableAutoScroll | Disable auto scroll to selected option | boolean | false |
+| disableAutoScroll | Disable auto scroll to selected option (only affects automatic scrolling in single-selection mode) | boolean | false |
 | direction | direction of dropdown | 'ltr' \| 'rtl' | 'ltr' |
 | optionRender | Custom rendering options | (oriOption: FlattenOptionData\<BaseOptionType\> , info: { index: number }) => React.ReactNode | - |
 | labelRender  | Custom rendering label   |  (props: LabelInValueType) => React.ReactNode   | - |

--- a/README.md
+++ b/README.md
@@ -122,11 +122,7 @@ export default () => (
 | dropdownRender | render custom dropdown menu | (menu: React.Node) => ReactNode | - |
 | loading | show loading icon in arrow | boolean | false |
 | virtual | Disable virtual scroll | boolean | true |
-| disableAutoScroll | Disable auto scroll to selected option (only affects automatic scrolling in single-selection mode) | boolean | false |
-| direction | direction of dropdown | 'ltr' \| 'rtl' | 'ltr' |
-| optionRender | Custom rendering options | (oriOption: FlattenOptionData\<BaseOptionType\> , info: { index: number }) => React.ReactNode | - |
-| labelRender  | Custom rendering label   |  (props: LabelInValueType) => React.ReactNode   | - |
-| maxCount | The max number of items can be selected | number | - |
+| disableAutoScroll | Disable auto scroll to selected option — only applies to single-select mode; does not affect multi-select or searchable scenarios | boolean | false | | direction | direction of dropdown | 'ltr' \| 'rtl' | 'ltr' | | optionRender | Custom rendering options | (oriOption: FlattenOptionData\<BaseOptionType\> , info: { index: number }) => React.ReactNode | - | | labelRender | Custom rendering label | (props: LabelInValueType) => React.ReactNode | - | | maxCount | The max number of items can be selected | number | - |
 
 ### Methods
 

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -52,6 +52,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
     flattenOptions,
     onActiveValue,
     defaultActiveFirstOption,
+    disableAutoScroll,
     onSelect,
     menuItemSelectedIcon,
     rawValues,
@@ -157,7 +158,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
      */
     let timeoutId: NodeJS.Timeout;
 
-    if (!multiple && open && rawValues.size === 1) {
+    if (!disableAutoScroll && !multiple && open && rawValues.size === 1) {
       const value: RawValueType = Array.from(rawValues)[0];
       // Scroll to the option closest to the searchValue if searching.
       const index = memoFlattenOptions.findIndex(({ data }) =>

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -179,7 +179,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
     }
 
     return () => clearTimeout(timeoutId);
-  }, [open, searchValue]);
+  }, [open, searchValue, disableAutoScroll]);
 
   // ========================== Values ==========================
   const onSelectValue = (value: RawValueType) => {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -164,6 +164,7 @@ export interface SelectProps<
     info: { index: number },
   ) => React.ReactNode;
   defaultActiveFirstOption?: boolean;
+  disableAutoScroll?: boolean;
   virtual?: boolean;
   direction?: 'ltr' | 'rtl';
   listHeight?: number;
@@ -214,6 +215,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       optionRender,
       children,
       defaultActiveFirstOption,
+      disableAutoScroll,
       menuItemSelectedIcon,
       virtual,
       direction,
@@ -675,6 +677,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
         flattenOptions: displayOptions,
         onActiveValue,
         defaultActiveFirstOption: mergedDefaultActiveFirstOption,
+        disableAutoScroll,
         onSelect: onInternalSelect,
         menuItemSelectedIcon,
         rawValues,
@@ -695,6 +698,7 @@ const Select = React.forwardRef<BaseSelectRef, SelectProps<any, DefaultOptionTyp
       displayOptions,
       onActiveValue,
       mergedDefaultActiveFirstOption,
+      disableAutoScroll,
       onInternalSelect,
       menuItemSelectedIcon,
       rawValues,

--- a/src/SelectContext.ts
+++ b/src/SelectContext.ts
@@ -37,6 +37,7 @@ export interface SelectContextProps {
   listItemHeight?: number;
   childrenAsData?: boolean;
   maxCount?: number;
+  disableAutoScroll?: boolean;
 }
 
 const SelectContext = React.createContext<SelectContextProps>(null);


### PR DESCRIPTION
The disableAutoScroll prop provides users with control over the automatic scrolling behavior in single-select 
mode. By default, the Select component automatically scrolls to the selected option when the dropdown opens, 
which can be disruptive in certain UX scenarios where users want to maintain their current scroll position or 
handle scrolling manually.

This addition allows developers to disable the auto-scroll behavior while preserving all other functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 为 Select 组件添加公有布尔属性 disableAutoScroll，可用于禁用选中单项时的自动滚动行为（默认 false）。

* **文档**
  * 更新组件文档与 API 表，新增 disableAutoScroll 属性说明及默认值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->