### PR TITLE
fix: prevent onSelect firing twice on Enter when dropdown is open

### DIFF
--- a/src/SelectInput/Input.tsx
+++ b/src/SelectInput/Input.tsx
@@ -95,7 +95,13 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     const { value: nextVal } = event.currentTarget;
 
     // Handle Enter key submission - referencing Selector implementation
-    if (key === 'Enter' && mode === 'tags' && !compositionStatusRef.current && onSearchSubmit) {
+    if (
+      key === 'Enter' &&
+      mode === 'tags' &&
+      !open &&
+      !compositionStatusRef.current &&
+      onSearchSubmit
+    ) {
       onSearchSubmit(nextVal);
     }
 

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -13,14 +13,7 @@ import openControlledTest from './shared/openControlledTest';
 import removeSelectedTest from './shared/removeSelectedTest';
 import maxTagRenderTest from './shared/maxTagRenderTest';
 import throwOptionValue from './shared/throwOptionValue';
-import {
-  injectRunAllTimers,
-  findSelection,
-  expectOpen,
-  toggleOpen,
-  keyDown,
-  keyUp,
-} from './utils/common';
+import { injectRunAllTimers, findSelection, expectOpen, toggleOpen, keyDown } from './utils/common';
 import type { CustomTagProps } from '@/BaseSelect';
 
 describe('Select.Tags', () => {
@@ -163,9 +156,8 @@ describe('Select.Tags', () => {
     );
     fireEvent.change(container.querySelector('input'), { target: { value: 'da' } });
     jest.runAllTimers();
-    fireEvent.mouseMove(container.querySelectorAll('.rc-select-item-option')[0]);
+    fireEvent.mouseMove(container.querySelector('.rc-select-item-option'));
     keyDown(container.querySelector('input'), KeyCode.ENTER);
-    keyUp(container.querySelector('input'), KeyCode.ENTER);
     jest.runAllTimers();
     expect(handleSelect).toHaveBeenCalledTimes(1);
   });

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -13,7 +13,14 @@ import openControlledTest from './shared/openControlledTest';
 import removeSelectedTest from './shared/removeSelectedTest';
 import maxTagRenderTest from './shared/maxTagRenderTest';
 import throwOptionValue from './shared/throwOptionValue';
-import { injectRunAllTimers, findSelection, expectOpen, toggleOpen, keyDown } from './utils/common';
+import {
+  injectRunAllTimers,
+  findSelection,
+  expectOpen,
+  toggleOpen,
+  keyDown,
+  keyUp,
+} from './utils/common';
 import type { CustomTagProps } from '@/BaseSelect';
 
 describe('Select.Tags', () => {
@@ -138,6 +145,29 @@ describe('Select.Tags', () => {
     expect(findSelection(container).textContent).toEqual('Star Kirby');
     expect(container.querySelector('input').value).toBe('');
     expectOpen(container, false);
+  });
+
+  it('should trigger onSelect once when pressing Enter to select option in tags mode (dropdown open)', () => {
+    const handleSelect = jest.fn();
+    const { container } = render(
+      <Select
+        mode="tags"
+        open
+        showSearch
+        onSelect={handleSelect}
+        options={[
+          { label: 'Dacryoadenitis', value: 'opt1' },
+          { label: 'Dacryocystitis', value: 'opt2' },
+        ]}
+      />,
+    );
+    fireEvent.change(container.querySelector('input'), { target: { value: 'da' } });
+    jest.runAllTimers();
+    fireEvent.mouseMove(container.querySelectorAll('.rc-select-item-option')[0]);
+    keyDown(container.querySelector('input'), KeyCode.ENTER);
+    keyUp(container.querySelector('input'), KeyCode.ENTER);
+    jest.runAllTimers();
+    expect(handleSelect).toHaveBeenCalledTimes(1);
   });
 
   // Paste tests

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -149,17 +149,18 @@ describe('Select.Tags', () => {
         showSearch
         onSelect={handleSelect}
         options={[
-          { label: 'Dacryoadenitis', value: 'opt1' },
-          { label: 'Dacryocystitis', value: 'opt2' },
+          { label: 'opt1', value: 'opt1' },
+          { label: 'opt2', value: 'opt2' },
         ]}
       />,
     );
-    fireEvent.change(container.querySelector('input'), { target: { value: 'da' } });
+    fireEvent.change(container.querySelector('input'), { target: { value: 'op' } });
     jest.runAllTimers();
-    fireEvent.mouseMove(container.querySelector('.rc-select-item-option'));
+    keyDown(container.querySelector('input'), KeyCode.DOWN);
     keyDown(container.querySelector('input'), KeyCode.ENTER);
     jest.runAllTimers();
     expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith('opt1', expect.anything());
   });
 
   // Paste tests


### PR DESCRIPTION
## 问题
在 `mode="tags"` 下，用户输入（如 "da"）后按回车选择下拉中的选项（如 "Dacryoadenitis"）时，`onSelect` 会触发两次：
1. 一次把输入内容当成新 tag（输入值）
2. 一次为选中的选项

## 关联缺陷

fix https://github.com/ant-design/ant-design/issues/57285

## 原因
语义化重构（#1166）之后，`SelectInput/Input.tsx` 里在 tags 模式下按 Enter 会无条件调用 `onSearchSubmit`。旧版 Selector 只在菜单**关闭**时（`!open`）才调用，重构时漏掉了这个条件，造成回归。

## 修改
仅在下拉**关闭**（`!open`）时调用 `onSearchSubmit`。下拉打开时由 OptionList 处理 Enter 选中当前高亮项（与 BaseSelect 注释中的设计一致）。

## 变更说明
- **src/SelectInput/Input.tsx**：在 tags 模式下，按 Enter 时增加 `!open` 判断再调用 `onSearchSubmit`。
- **tests/Tags.test.tsx**：新增用例「should trigger onSelect once when pressing Enter to select option in tags mode (dropdown open)」，防止该问题再次出现。

## 验证
- 去掉本次修改：新用例失败（onSelect 被调用两次）。
- 保留本次修改：新用例通过（onSelect 仅调用一次）。
- 下拉关闭时按 Enter 仍会把输入当新 tag 添加，行为不变。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复标签模式下 Enter 键行为：仅在下拉关闭时才触发提交，避免在列表打开时误触发提交或选择。

* **Tests**
  * 新增测试用例：验证在标签模式且列表打开时按 Enter 仅触发一次选中行为，确保交互稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->