### PR TITLE
feat: support function tokenSeparators for custom tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export default () => (
 | dropdownAlign | additional align applied to dropdown | [AlignType](https://github.com/react-component/trigger/blob/728d7e92394aa4b3214650f743fc47e1382dfa68/src/interface.ts#L25-L80) | {} |
 | dropdownMenuStyle | additional style applied to dropdown menu | Object | React.CSSProperties |
 | notFoundContent | specify content to show when no result matches. | ReactNode | 'Not Found' |
-| tokenSeparators | separator used to tokenize on tag/multiple mode | string[]? |  |
+| tokenSeparators | separator used to tokenize on tag/multiple mode | `string[] \| ((input: string) => string[])` |  |
 | open | control select open | boolean |  |
 | defaultOpen | control select default open | boolean |  |
 | placeholder | select placeholder | React Node |  |

--- a/docs/demo/custom-tokenize.md
+++ b/docs/demo/custom-tokenize.md
@@ -1,0 +1,8 @@
+---
+title: custom-tokenize
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/custom-tokenize.tsx"></code>

--- a/docs/examples/custom-tokenize.tsx
+++ b/docs/examples/custom-tokenize.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Select from '@rc-component/select';
+import '../../assets/index.less';
+
+const tokenize = (input: string): string[] => {
+  const tokens: string[] = [];
+  const regex = /"([^"]*)"|([^,\n]+)/g;
+  let m: RegExpExecArray | null = regex.exec(input);
+  while (m !== null) {
+    tokens.push((m[1] ?? m[2]).trim());
+    m = regex.exec(input);
+  }
+  return tokens.filter(Boolean);
+};
+
+const Demo: React.FC = () => (
+  <>
+    <h2>自定义分词（引号感知）</h2>
+    <Select
+      mode="tags"
+      style={{ width: '100%' }}
+      tokenize={tokenize}
+      placeholder='Try paste: "San Francisco, CA", New York'
+    />
+  </>
+);
+
+export default Demo;

--- a/docs/examples/custom-tokenize.tsx
+++ b/docs/examples/custom-tokenize.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Select from '@rc-component/select';
 import '../../assets/index.less';
 
-const tokenize = (input: string): string[] => {
+const tokenSeparators = (input: string): string[] => {
   const tokens: string[] = [];
   const regex = /"([^"]*)"|([^,\n]+)/g;
   let m: RegExpExecArray | null = regex.exec(input);
@@ -19,7 +19,7 @@ const Demo: React.FC = () => (
     <Select
       mode="tags"
       style={{ width: '100%' }}
-      tokenize={tokenize}
+      tokenSeparators={tokenSeparators}
       placeholder='Try paste: "San Francisco, CA", New York'
     />
   </>

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -183,6 +183,12 @@ export interface BaseSelectProps
 
   // >>> Search
   tokenSeparators?: string[];
+  /**
+   * Custom tokenization. When provided, takes precedence over `tokenSeparators`.
+   * Receives the current input text and returns an array of tags. Return `[input]`
+   * (or any single-element array equal to input) to indicate "no split, keep typing".
+   */
+  tokenize?: (input: string) => string[];
 
   // >>> Icons
   allowClear?: boolean | { clearIcon?: React.ReactNode };
@@ -282,6 +288,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     onSearch,
     onSearchSplit,
     tokenSeparators,
+    tokenize,
 
     // Icons
     allowClear,
@@ -371,8 +378,10 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
 
   // ============================= Search =============================
   const tokenWithEnter = React.useMemo<boolean>(
-    () => (tokenSeparators || []).some((tokenSeparator) => ['\n', '\r\n'].includes(tokenSeparator)),
-    [tokenSeparators],
+    () =>
+      !!tokenize ||
+      (tokenSeparators || []).some((tokenSeparator) => ['\n', '\r\n'].includes(tokenSeparator)),
+    [tokenize, tokenSeparators],
   );
 
   const onInternalSearch = (searchText: string, fromTyping: boolean, isCompositing: boolean) => {
@@ -383,13 +392,22 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     let newSearchText = searchText;
     onActiveValueChange?.(null);
 
-    const separatedList = getSeparatedContent(
-      searchText,
-      tokenSeparators,
-      isValidCount(maxCount) ? maxCount - displayValues.length : undefined,
-    );
+    const cap = isValidCount(maxCount) ? maxCount - displayValues.length : undefined;
 
-    // Check if match the `tokenSeparators`
+    let separatedList: string[] | null;
+    if (tokenize) {
+      const tokens = tokenize(searchText);
+      const isUnchanged = Array.isArray(tokens) && tokens.length === 1 && tokens[0] === searchText;
+      if (Array.isArray(tokens) && tokens.length > 0 && !isUnchanged) {
+        separatedList = typeof cap !== 'undefined' ? tokens.slice(0, cap) : tokens;
+      } else {
+        separatedList = null;
+      }
+    } else {
+      separatedList = getSeparatedContent(searchText, tokenSeparators, cap);
+    }
+
+    // Check if match the `tokenSeparators` or custom `tokenize`
     const patchLabels: string[] = isCompositing ? null : separatedList;
 
     // Ignore combobox since it's not split-able

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -395,7 +395,9 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     const cap = isValidCount(maxCount) ? maxCount - displayValues.length : undefined;
 
     let separatedList: string[] | null;
-    if (tokenize) {
+    if (isCompositing) {
+      separatedList = null;
+    } else if (tokenize) {
       const tokens = tokenize(searchText);
       const isUnchanged = Array.isArray(tokens) && tokens.length === 1 && tokens[0] === searchText;
       if (Array.isArray(tokens) && tokens.length > 0 && !isUnchanged) {
@@ -408,7 +410,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     }
 
     // Check if match the `tokenSeparators` or custom `tokenize`
-    const patchLabels: string[] = isCompositing ? null : separatedList;
+    const patchLabels = separatedList;
 
     // Ignore combobox since it's not split-able
     if (mode !== 'combobox' && patchLabels) {

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -182,13 +182,7 @@ export interface BaseSelectProps
   maxTagPlaceholder?: React.ReactNode | ((omittedValues: DisplayValueType[]) => React.ReactNode);
 
   // >>> Search
-  tokenSeparators?: string[];
-  /**
-   * Custom tokenization. When provided, takes precedence over `tokenSeparators`.
-   * Receives the current input text and returns an array of tags. Return `[input]`
-   * (or any single-element array equal to input) to indicate "no split, keep typing".
-   */
-  tokenize?: (input: string) => string[];
+  tokenSeparators?: string[] | ((input: string) => string[]);
 
   // >>> Icons
   allowClear?: boolean | { clearIcon?: React.ReactNode };
@@ -288,7 +282,6 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     onSearch,
     onSearchSplit,
     tokenSeparators,
-    tokenize,
 
     // Icons
     allowClear,
@@ -379,10 +372,29 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
   // ============================= Search =============================
   const tokenWithEnter = React.useMemo<boolean>(
     () =>
-      !!tokenize ||
+      typeof tokenSeparators === 'function' ||
       (tokenSeparators || []).some((tokenSeparator) => ['\n', '\r\n'].includes(tokenSeparator)),
-    [tokenize, tokenSeparators],
+    [tokenSeparators],
   );
+
+  const splitByTokenSeparators = React.useMemo<
+    (input: string, end?: number) => string[] | null
+  >(() => {
+    if (typeof tokenSeparators === 'function') {
+      return (input: string, end?: number) => {
+        const tokens = tokenSeparators(input);
+        const isUnchanged = Array.isArray(tokens) && tokens.length === 1 && tokens[0] === input;
+
+        if (!Array.isArray(tokens) || !tokens.length || isUnchanged) {
+          return null;
+        }
+
+        return typeof end !== 'undefined' ? tokens.slice(0, end) : tokens;
+      };
+    }
+
+    return (input: string, end?: number) => getSeparatedContent(input, tokenSeparators, end);
+  }, [tokenSeparators]);
 
   const onInternalSearch = (searchText: string, fromTyping: boolean, isCompositing: boolean) => {
     if (multiple && isValidCount(maxCount) && displayValues.length >= maxCount) {
@@ -393,24 +405,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
     onActiveValueChange?.(null);
 
     const cap = isValidCount(maxCount) ? maxCount - displayValues.length : undefined;
-
-    let separatedList: string[] | null;
-    if (isCompositing) {
-      separatedList = null;
-    } else if (tokenize) {
-      const tokens = tokenize(searchText);
-      const isUnchanged = Array.isArray(tokens) && tokens.length === 1 && tokens[0] === searchText;
-      if (Array.isArray(tokens) && tokens.length > 0 && !isUnchanged) {
-        separatedList = typeof cap !== 'undefined' ? tokens.slice(0, cap) : tokens;
-      } else {
-        separatedList = null;
-      }
-    } else {
-      separatedList = getSeparatedContent(searchText, tokenSeparators, cap);
-    }
-
-    // Check if match the `tokenSeparators` or custom `tokenize`
-    const patchLabels = separatedList;
+    const patchLabels = isCompositing ? null : splitByTokenSeparators(searchText, cap);
 
     // Ignore combobox since it's not split-able
     if (mode !== 'combobox' && patchLabels) {

--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -40,7 +40,7 @@ export interface SelectInputProps extends Omit<React.HTMLAttributes<HTMLDivEleme
   onSelectorRemove?: (value: DisplayValueType) => void;
   maxLength?: number;
   autoFocus?: boolean;
-  /** Check if `tokenSeparators` contains `\n` or `\r\n` */
+  /** Check if tokenization should treat pasted line breaks as separators */
   tokenWithEnter?: boolean;
   // Add other props that need to be passed through
   className?: string;

--- a/tests/Multiple.test.tsx
+++ b/tests/Multiple.test.tsx
@@ -80,6 +80,34 @@ describe('Select.Multiple', () => {
     expectOpen(container, false);
   });
 
+  it('tokenize prop on multiple only adds values that match options', () => {
+    const handleChange = jest.fn();
+    const tokenize = (input: string) => input.split(',').map((s) => s.trim());
+    const { container } = render(
+      <Select
+        mode="multiple"
+        optionLabelProp="children"
+        tokenize={tokenize}
+        onChange={handleChange}
+      >
+        <OptGroup key="group1">
+          <Option value="1">One</Option>
+        </OptGroup>
+        <OptGroup key="group2">
+          <Option value="2">Two</Option>
+        </OptGroup>
+      </Select>,
+    );
+    fireEvent.paste(container.querySelector('input'), {
+      clipboardData: { getData: () => 'One,Two,Unknown' },
+    });
+    fireEvent.change(container.querySelector('input'), {
+      target: { value: 'One,Two,Unknown' },
+    });
+    expect(handleChange).toHaveBeenCalledWith(['1', '2'], expect.anything());
+    expect(container.querySelector('input').value).toBe('');
+  });
+
   it('tokenize input when mode=tags and open=false', () => {
     const handleChange = jest.fn();
     const handleSelect = jest.fn();

--- a/tests/Multiple.test.tsx
+++ b/tests/Multiple.test.tsx
@@ -80,14 +80,14 @@ describe('Select.Multiple', () => {
     expectOpen(container, false);
   });
 
-  it('tokenize prop on multiple only adds values that match options', () => {
+  it('tokenSeparators function on multiple only adds values that match options', () => {
     const handleChange = jest.fn();
-    const tokenize = (input: string) => input.split(',').map((s) => s.trim());
+    const tokenSeparators = (input: string) => input.split(',').map((s) => s.trim());
     const { container } = render(
       <Select
         mode="multiple"
         optionLabelProp="children"
-        tokenize={tokenize}
+        tokenSeparators={tokenSeparators}
         onChange={handleChange}
       >
         <OptGroup key="group1">

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -82,9 +82,9 @@ describe('Select.Tags', () => {
     expectOpen(container, false);
   });
 
-  it('tokenize prop overrides tokenSeparators with quote-aware splitting', () => {
+  it('tokenSeparators function overrides string token split with quote-aware splitting', () => {
     const handleChange = jest.fn();
-    const tokenize = jest.fn((input: string) => {
+    const tokenSeparators = jest.fn((input: string) => {
       const tokens: string[] = [];
       const regex = /"([^"]*)"|([^,\n]+)/g;
       let m: RegExpExecArray | null = regex.exec(input);
@@ -95,33 +95,33 @@ describe('Select.Tags', () => {
       return tokens.filter(Boolean);
     });
     const { container } = render(
-      <Select mode="tags" tokenSeparators={[',']} tokenize={tokenize} onChange={handleChange}>
+      <Select mode="tags" tokenSeparators={tokenSeparators} onChange={handleChange}>
         <Option value="1">1</Option>
       </Select>,
     );
 
     fireEvent.change(container.querySelector('input'), { target: { value: '"a, b", c' } });
 
-    expect(tokenize).toHaveBeenCalled();
+    expect(tokenSeparators).toHaveBeenCalled();
     expect(handleChange).toHaveBeenCalledWith(['a, b', 'c'], expect.anything());
     expect(container.querySelector('input').value).toBe('');
   });
 
-  it('tokenize prop respects maxCount', () => {
+  it('tokenSeparators function respects maxCount', () => {
     const handleChange = jest.fn();
-    const tokenize = () => ['a', 'b', 'c', 'd', 'e'];
+    const tokenSeparators = () => ['a', 'b', 'c', 'd', 'e'];
     const { container } = render(
-      <Select mode="tags" maxCount={3} tokenize={tokenize} onChange={handleChange} />,
+      <Select mode="tags" maxCount={3} tokenSeparators={tokenSeparators} onChange={handleChange} />,
     );
     fireEvent.change(container.querySelector('input'), { target: { value: 'x' } });
     expect(handleChange).toHaveBeenCalledWith(['a', 'b', 'c'], expect.anything());
   });
 
-  it('tokenize prop ignored during composition', () => {
+  it('tokenSeparators function ignored during composition', () => {
     const handleChange = jest.fn();
-    const tokenize = (input: string) => input.split(',').map((s) => s.trim());
+    const tokenSeparators = (input: string) => input.split(',').map((s) => s.trim());
     const { container } = render(
-      <Select mode="tags" tokenize={tokenize} onChange={handleChange}>
+      <Select mode="tags" tokenSeparators={tokenSeparators} onChange={handleChange}>
         <Option value="1">1</Option>
       </Select>,
     );
@@ -134,11 +134,11 @@ describe('Select.Tags', () => {
     expect(handleChange).toHaveBeenCalledWith(['2', '3', '4'], expect.anything());
   });
 
-  it('tokenize prop returning [input] keeps typing', () => {
+  it('tokenSeparators function returning [input] keeps typing', () => {
     const handleChange = jest.fn();
-    const tokenize = (input: string) => [input];
+    const tokenSeparators = (input: string) => [input];
     const { container } = render(
-      <Select mode="tags" tokenize={tokenize} onChange={handleChange}>
+      <Select mode="tags" tokenSeparators={tokenSeparators} onChange={handleChange}>
         <Option value="1">1</Option>
       </Select>,
     );

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -82,6 +82,71 @@ describe('Select.Tags', () => {
     expectOpen(container, false);
   });
 
+  it('tokenize prop overrides tokenSeparators with quote-aware splitting', () => {
+    const handleChange = jest.fn();
+    const tokenize = jest.fn((input: string) => {
+      const tokens: string[] = [];
+      const regex = /"([^"]*)"|([^,\n]+)/g;
+      let m: RegExpExecArray | null = regex.exec(input);
+      while (m !== null) {
+        tokens.push((m[1] ?? m[2]).trim());
+        m = regex.exec(input);
+      }
+      return tokens.filter(Boolean);
+    });
+    const { container } = render(
+      <Select mode="tags" tokenSeparators={[',']} tokenize={tokenize} onChange={handleChange}>
+        <Option value="1">1</Option>
+      </Select>,
+    );
+
+    fireEvent.change(container.querySelector('input'), { target: { value: '"a, b", c' } });
+
+    expect(tokenize).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalledWith(['a, b', 'c'], expect.anything());
+    expect(container.querySelector('input').value).toBe('');
+  });
+
+  it('tokenize prop respects maxCount', () => {
+    const handleChange = jest.fn();
+    const tokenize = () => ['a', 'b', 'c', 'd', 'e'];
+    const { container } = render(
+      <Select mode="tags" maxCount={3} tokenize={tokenize} onChange={handleChange} />,
+    );
+    fireEvent.change(container.querySelector('input'), { target: { value: 'x' } });
+    expect(handleChange).toHaveBeenCalledWith(['a', 'b', 'c'], expect.anything());
+  });
+
+  it('tokenize prop ignored during composition', () => {
+    const handleChange = jest.fn();
+    const tokenize = (input: string) => input.split(',').map((s) => s.trim());
+    const { container } = render(
+      <Select mode="tags" tokenize={tokenize} onChange={handleChange}>
+        <Option value="1">1</Option>
+      </Select>,
+    );
+    fireEvent.compositionStart(container.querySelector('input'));
+    fireEvent.change(container.querySelector('input'), { target: { value: '2,3,4' } });
+    expect(handleChange).not.toHaveBeenCalled();
+    handleChange.mockReset();
+    fireEvent.compositionEnd(container.querySelector('input'));
+    fireEvent.change(container.querySelector('input'), { target: { value: '2,3,4' } });
+    expect(handleChange).toHaveBeenCalledWith(['2', '3', '4'], expect.anything());
+  });
+
+  it('tokenize prop returning [input] keeps typing', () => {
+    const handleChange = jest.fn();
+    const tokenize = (input: string) => [input];
+    const { container } = render(
+      <Select mode="tags" tokenize={tokenize} onChange={handleChange}>
+        <Option value="1">1</Option>
+      </Select>,
+    );
+    fireEvent.change(container.querySelector('input'), { target: { value: 'hello' } });
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(container.querySelector<HTMLInputElement>('input').value).toBe('hello');
+  });
+
   it('should not separate words when compositing but trigger after composition end', () => {
     const handleChange = jest.fn();
     const handleSelect = jest.fn();


### PR DESCRIPTION
## Summary
- Extend `tokenSeparators` to support both `string[]` and `(input: string) => string[]` for custom tokenization in `tags`/`multiple` modes.
- Normalize internal token split handling through `tokenSeparators` (instead of introducing a separate `tokenize` prop), while preserving IME composition behavior and `maxCount` limiting.
- Update tests and demo/docs to cover quote-aware function tokenization usage.
## Related
- ant-design/ant-design#57820

## Test plan
- [x] `npm test -- tests/Tags.test.tsx tests/Multiple.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 令牌分割支持扩展为可提供自定义分词函数，增强对引号等复杂输入的识别与处理，适用于多选与标签模式并尊重最大数量限制。

* **文档**
  * 新增演示页面与示例代码，展示基于引号感知的令牌分割用法与占位提示；更新属性说明以反映新的函数式分词支持。

* **测试**
  * 增加多项自动化测试，覆盖多选、标签、IME 组合输入、最大数量截断及函数式分词行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/select/pull/1220)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->