### PR TITLE
feat: add inputProps prop to pass props to internal input

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ export default () => (
 | optionRender | Custom rendering options | (oriOption: FlattenOptionData\<BaseOptionType\> , info: { index: number }) => React.ReactNode | - |
 | labelRender  | Custom rendering label   |  (props: LabelInValueType) => React.ReactNode   | - |
 | maxCount | The max number of items can be selected | number | - |
+| inputProps | props passed to the internal input element | React.InputHTMLAttributes<HTMLInputElement> | - |
 
 ### Methods
 

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -130,8 +130,7 @@ export interface BaseSelectPrivateProps {
 export type BaseSelectPropsWithoutPrivate = Omit<BaseSelectProps, keyof BaseSelectPrivateProps>;
 
 export interface BaseSelectProps
-  extends
-    BaseSelectPrivateProps,
+  extends BaseSelectPrivateProps,
     React.AriaAttributes,
     Pick<React.HTMLAttributes<HTMLElement>, 'role'> {
   // Style
@@ -229,6 +228,10 @@ export interface BaseSelectProps
 
   // >>> Components
   components?: ComponentsConfig;
+
+  // >>> Input
+  /** Props passed to the internal input element */
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 export const isMultiple = (mode: Mode) => mode === 'tags' || mode === 'multiple';

--- a/src/SelectInput/Content/index.tsx
+++ b/src/SelectInput/Content/index.tsx
@@ -10,7 +10,12 @@ export interface SharedContentProps {
 }
 
 const SelectContent = React.forwardRef<HTMLInputElement>(function SelectContent(_, ref) {
-  const { multiple, onInputKeyDown, tabIndex } = useSelectInputContext();
+  const {
+    multiple,
+    onInputKeyDown,
+    tabIndex,
+    inputProps: userInputProps,
+  } = useSelectInputContext();
   const baseProps = useBaseProps();
   const { showSearch } = baseProps;
 
@@ -18,6 +23,7 @@ const SelectContent = React.forwardRef<HTMLInputElement>(function SelectContent(
 
   const sharedInputProps: SharedContentProps['inputProps'] = {
     ...ariaProps,
+    ...userInputProps,
     onKeyDown: onInputKeyDown,
     readOnly: !showSearch,
     tabIndex,

--- a/src/SelectInput/Input.tsx
+++ b/src/SelectInput/Input.tsx
@@ -21,6 +21,8 @@ export interface InputProps {
   syncWidth?: boolean;
   /** autoComplete for input */
   autoComplete?: string;
+  /** Props passed to the internal input element */
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
@@ -33,6 +35,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     value,
     className,
     autoComplete,
+    inputProps,
     ...restProps
   } = props;
   const {
@@ -164,6 +167,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     id,
     type: mode === 'combobox' ? 'text' : 'search',
     ...restProps,
+    ...inputProps,
     ref: inputRef as React.Ref<HTMLInputElement>,
     style: {
       ...styles?.input,

--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -67,6 +67,7 @@ const DEFAULT_OMIT_PROPS = [
   'activeValue',
   'onSelectorRemove',
   'focused',
+  'inputProps',
 ] as const;
 
 export default React.forwardRef<SelectInputRef, SelectInputProps>(function SelectInput(

--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -48,6 +48,8 @@ export interface SelectInputProps extends Omit<React.HTMLAttributes<HTMLDivEleme
   focused?: boolean;
   components: ComponentsConfig;
   children?: React.ReactElement;
+  /** Props passed to the internal input element */
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 const DEFAULT_OMIT_PROPS = [

--- a/tests/BaseSelect.test.tsx
+++ b/tests/BaseSelect.test.tsx
@@ -190,4 +190,24 @@ describe('BaseSelect', () => {
     expect(container.querySelector('.custom-root-element')).toBeTruthy();
     expect(container.querySelector('.rc-select')).toBeFalsy();
   });
+
+  it('should pass inputProps to internal input', () => {
+    const { container } = render(
+      <BaseSelect
+        prefixCls="rc-select"
+        showSearch
+        inputProps={{ spellCheck: false }}
+        OptionList={OptionList}
+        displayValues={[]}
+        emptyOptions
+        id="test"
+        onDisplayValuesChange={() => {}}
+        onSearch={() => {}}
+        searchValue=""
+      />,
+    );
+
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('spellcheck')).toBe('false');
+  });
 });


### PR DESCRIPTION
### Background

Users need to customize the internal input element of Select component (e.g., disable spellCheck). Currently there's no way to pass props to the internal input.

### Changes

1. **src/BaseSelect/index.tsx** - Add `inputProps` to BaseSelectProps interface
2. **src/SelectInput/index.tsx** - Add `inputProps` to SelectInputProps interface  
3. **src/SelectInput/Input.tsx** - Add `inputProps` type and merge to sharedInputProps
4. **src/SelectInput/Content/index.tsx** - Merge user inputProps with default props
5. **tests/BaseSelect.test.tsx** - Add test case
6. **README.md** - Add API documentation

### Usage

```tsx
// Disable spellCheck
<Select showSearch inputProps={{ spellCheck: false }} />
```

### Related Issue

- ant-design/ant-design#38012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为 Select 组件及其子组件新增了 inputProps 属性，允许将标准 HTML 输入属性传递到内部 input 元素以便定制。

* **测试**
  * 增加测试，验证 inputProps 能正确转发并影响内部 input（例如 spellcheck 属性）。

* **文档**
  * 更新 README 中的 API 文档，新增 inputProps 的说明与类型示例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->