### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
   "dependencies": {
     "@rc-component/overflow": "^1.0.0",
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.3.0",
-    "@rc-component/virtual-list": "^1.0.1",
+    "@rc-component/util": "^1.11.1",
+    "@rc-component/virtual-list": "^1.2.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.6",

--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -1,7 +1,7 @@
-import type { AlignType, BuildInPlacements } from '@rc-component/trigger/lib/interface';
+import type { AlignType, BuildInPlacements } from '@rc-component/trigger';
 import { clsx } from 'clsx';
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import type { ScrollConfig, ScrollTo } from '@rc-component/virtual-list/lib/List';
+import { getDOM, useEvent } from '@rc-component/util';
+import type { ScrollConfig, ScrollTo } from '@rc-component/virtual-list';
 import * as React from 'react';
 import { useAllowClear } from '../hooks/useAllowClear';
 import { BaseSelectContext } from '../hooks/useBaseProps';
@@ -22,7 +22,6 @@ import SelectTrigger from '../SelectTrigger';
 import { getSeparatedContent, isValidCount } from '../utils/valueUtil';
 import Polite from './Polite';
 import useOpen, { macroTask } from '../hooks/useOpen';
-import { useEvent } from '@rc-component/util';
 import type { SelectInputRef } from '../SelectInput';
 import SelectInput from '../SelectInput';
 import type { ComponentsConfig } from '../hooks/useComponents';

--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -1,11 +1,6 @@
 import { clsx } from 'clsx';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import useMemo from '@rc-component/util/lib/hooks/useMemo';
-import omit from '@rc-component/util/lib/omit';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
-import type { ListRef } from '@rc-component/virtual-list';
-import List from '@rc-component/virtual-list';
-import type { ScrollConfig } from '@rc-component/virtual-list/lib/List';
+import { KeyCode, omit, pickAttrs, useMemo } from '@rc-component/util';
+import List, { type ListRef, type ScrollConfig } from '@rc-component/virtual-list';
 import * as React from 'react';
 import { useEffect } from 'react';
 import type { BaseOptionType, RawValueType } from './Select';

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -29,8 +29,7 @@
  * - `combobox` mode not support `optionLabelProp`
  */
 
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import warning from '@rc-component/util/lib/warning';
+import { useControlledState, useId, warning } from '@rc-component/util';
 import * as React from 'react';
 import type {
   BaseSelectProps,
@@ -49,7 +48,6 @@ import SelectContext from './SelectContext';
 import type { SelectContextProps } from './SelectContext';
 import useCache from './hooks/useCache';
 import useFilterOptions from './hooks/useFilterOptions';
-import useId from '@rc-component/util/lib/hooks/useId';
 import useOptions from './hooks/useOptions';
 import useRefFunc from './hooks/useRefFunc';
 import type { FlattenOptionData } from './interface';

--- a/src/SelectInput/Content/index.tsx
+++ b/src/SelectInput/Content/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs } from '@rc-component/util';
 import SingleContent from './SingleContent';
 import MultipleContent from './MultipleContent';
 import { useSelectInputContext } from '../context';

--- a/src/SelectInput/Input.tsx
+++ b/src/SelectInput/Input.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 import { useSelectInputContext } from './context';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { composeRef, useLayoutEffect } from '@rc-component/util';
 import useBaseProps from '../hooks/useBaseProps';
-import { composeRef } from '@rc-component/util/lib/ref';
 
 export interface InputProps {
   id?: string;

--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -4,14 +4,10 @@ import SelectContent from './Content';
 import SelectInputContext from './context';
 import type { DisplayValueType, Mode, RenderNode } from '../interface';
 import useBaseProps from '../hooks/useBaseProps';
-import { omit, useEvent } from '@rc-component/util';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { composeRef, getDOM, KeyCode, omit, pickAttrs, useEvent } from '@rc-component/util';
 import { isValidateOpenKey } from '../utils/keyUtil';
 import { clsx } from 'clsx';
 import type { ComponentsConfig } from '../hooks/useComponents';
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import { composeRef } from '@rc-component/util/lib/ref';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
 export interface SelectInputRef {
   focus: (options?: FocusOptions) => void;

--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -1,5 +1,8 @@
-import Trigger, { type TriggerRef } from '@rc-component/trigger';
-import type { AlignType, BuildInPlacements } from '@rc-component/trigger/lib/interface';
+import Trigger, {
+  type AlignType,
+  type BuildInPlacements,
+  type TriggerRef,
+} from '@rc-component/trigger';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import type { Placement, RenderDOMFunc } from './BaseSelect';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,35 @@
 import Select from './Select';
 import Option from './Option';
 import OptGroup from './OptGroup';
-import type { SelectProps } from './Select';
+import type { BaseOptionType, DefaultOptionType, SearchConfig, SelectProps } from './Select';
 import BaseSelect from './BaseSelect';
-import type { BaseSelectProps, BaseSelectRef, BaseSelectPropsWithoutPrivate } from './BaseSelect';
+import type {
+  BaseSelectProps,
+  BaseSelectPropsWithoutPrivate,
+  BaseSelectRef,
+  BaseSelectSemanticName,
+  DisplayValueType,
+  RefOptionListProps,
+} from './BaseSelect';
 import useBaseProps from './hooks/useBaseProps';
+import type { OptionFC, OptionProps } from './Option';
+import type { Placement } from './interface';
 
 export { Option, OptGroup, BaseSelect, useBaseProps };
-export type { SelectProps, BaseSelectProps, BaseSelectRef, BaseSelectPropsWithoutPrivate };
+export type {
+  BaseOptionType,
+  BaseSelectProps,
+  BaseSelectPropsWithoutPrivate,
+  BaseSelectRef,
+  BaseSelectSemanticName,
+  DefaultOptionType,
+  DisplayValueType,
+  OptionFC,
+  OptionProps,
+  Placement,
+  RefOptionListProps,
+  SearchConfig,
+  SelectProps,
+};
 
 export default Select;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,33 +3,12 @@ import Option from './Option';
 import OptGroup from './OptGroup';
 import type { BaseOptionType, DefaultOptionType, SearchConfig, SelectProps } from './Select';
 import BaseSelect from './BaseSelect';
-import type {
-  BaseSelectProps,
-  BaseSelectPropsWithoutPrivate,
-  BaseSelectRef,
-  BaseSelectSemanticName,
-  DisplayValueType,
-  RefOptionListProps,
-} from './BaseSelect';
+import type { BaseSelectProps, BaseSelectRef, BaseSelectPropsWithoutPrivate } from './BaseSelect';
 import useBaseProps from './hooks/useBaseProps';
-import type { OptionFC, OptionProps } from './Option';
-import type { Placement } from './interface';
+import type { OptionProps } from './Option';
 
 export { Option, OptGroup, BaseSelect, useBaseProps };
-export type {
-  BaseOptionType,
-  BaseSelectProps,
-  BaseSelectPropsWithoutPrivate,
-  BaseSelectRef,
-  BaseSelectSemanticName,
-  DefaultOptionType,
-  DisplayValueType,
-  OptionFC,
-  OptionProps,
-  Placement,
-  RefOptionListProps,
-  SearchConfig,
-  SelectProps,
-};
+export type { BaseOptionType, DefaultOptionType, OptionProps, SearchConfig };
+export type { SelectProps, BaseSelectProps, BaseSelectRef, BaseSelectPropsWithoutPrivate };
 
 export default Select;

--- a/src/utils/keyUtil.ts
+++ b/src/utils/keyUtil.ts
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 
 /** keyCode Judgment function */
 export function isValidateOpenKey(currentKeyCode: number): boolean {

--- a/src/utils/legacyUtil.ts
+++ b/src/utils/legacyUtil.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import toArray from '@rc-component/util/lib/Children/toArray';
+import { toArray } from '@rc-component/util';
 import type { BaseOptionType, DefaultOptionType } from '../Select';
 
 function convertNodeToOption<OptionType extends BaseOptionType = DefaultOptionType>(

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -1,5 +1,5 @@
 import type { BaseOptionType, DefaultOptionType } from '../Select';
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import type { RawValueType, FieldNames } from '../Select';
 import type { FlattenOptionData } from '../interface';
 

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -1,5 +1,4 @@
-import toNodeArray from '@rc-component/util/lib/Children/toArray';
-import warning, { noteOnce } from '@rc-component/util/lib/warning';
+import { noteOnce, toArray as toNodeArray, warning as warning } from '@rc-component/util';
 import * as React from 'react';
 import { isMultiple } from '../BaseSelect';
 import type {

--- a/tests/Accessibility.test.tsx
+++ b/tests/Accessibility.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import Select from '../src';
 import { injectRunAllTimers, expectOpen, keyDown } from './utils/common';
 import { act, fireEvent, render } from '@testing-library/react';

--- a/tests/Combobox.test.tsx
+++ b/tests/Combobox.test.tsx
@@ -2,8 +2,7 @@
 
 import '@testing-library/jest-dom';
 import { createEvent, fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { KeyCode, resetWarned } from '@rc-component/util';
 import React, { act } from 'react';
 import type { SelectProps } from '../src';
 import Select, { Option } from '../src';

--- a/tests/Multiple.test.tsx
+++ b/tests/Multiple.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import Select, { Option, OptGroup } from '../src';
 import focusTest from './shared/focusTest';

--- a/tests/OptionList.test.tsx
+++ b/tests/OptionList.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode, spyElementPrototypes } from '@rc-component/util';
 import React, { act } from 'react';
 import { BaseSelectContext } from '../src/hooks/useBaseProps';
 import type { RefOptionListProps } from '../src/OptionList';
@@ -8,7 +8,6 @@ import { fillFieldNames, flattenOptions } from '../src/utils/valueUtil';
 import { injectRunAllTimers } from './utils/common';
 import { createEvent, fireEvent, render, waitFor } from '@testing-library/react';
 import Select from '../src';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 
 jest.mock('../src/utils/platformUtil');
 

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -6,10 +6,8 @@ import {
   render as testingRender,
   act,
 } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
-import { resetWarned } from '@rc-component/util/lib/warning';
-import type { ScrollConfig } from '@rc-component/virtual-list/lib/List';
+import { KeyCode, resetWarned, spyElementPrototypes } from '@rc-component/util';
+import type { ScrollConfig } from '@rc-component/virtual-list';
 import React, { StrictMode } from 'react';
 import type { SelectProps } from '../src';
 import Select, { OptGroup, Option, useBaseProps } from '../src';

--- a/tests/Tags.test.tsx
+++ b/tests/Tags.test.tsx
@@ -1,5 +1,5 @@
 import { createEvent, fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import Select, { BaseSelect, OptGroup, Option } from '../src';

--- a/tests/shared/focusTest.tsx
+++ b/tests/shared/focusTest.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import Option from '../../src/Option';
 import Select from '../../src/Select';
 import { render } from '@testing-library/react';

--- a/tests/shared/removeSelectedTest.tsx
+++ b/tests/shared/removeSelectedTest.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import Select, { Option } from '../../src';
 import { removeSelection, toggleOpen, selectItem, keyDown } from '../utils/common';

--- a/tests/shared/throwOptionValue.tsx
+++ b/tests/shared/throwOptionValue.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Select, { Option } from '../../src';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import { render } from '@testing-library/react';
 
 export default function throwOptionValue(mode: any) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,6 +4,4 @@ declare module 'component-classes';
 
 declare module 'rc-menu';
 
-declare module '@rc-component/util/lib/Children/toArray';
-
 declare module 'dom-scroll-into-view';


### PR DESCRIPTION
## 背景

避免 rc 包之间继续依赖 `es` / `lib` 构建产物路径，统一改为从包根入口导入公开 API。

## 调整内容

- 升级 `@rc-component/father-plugin`，交由插件统一限制深路径导入。
- 升级 `@rc-component/util` 与 `@rc-component/virtual-list`，使用根入口已导出的 API。
- 将当前包内对其他 rc 包 `lib` 路径的导入替换为包根入口导入。
- 补充 `@rc-component/select` 根入口类型导出，方便下游包和 antd 去除深路径导入。
- 移除不再需要的临时 typings 声明。

## 验证

- `npm run lint` 通过，仅存在项目已有 warning。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新依赖：`@rc-component/util` 升至 v1.11.1，`@rc-component/virtual-list` 升至 v1.2.0，`@rc-component/father-plugin` 升至 v2.2.0

* **Refactor**
  * 统一并简化模块导入方式，优化包入口使用，代码组织更一致

* **其他**
  * 扩展导出类型以提升类型支持；移除已弃用的类型声明文件条目

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/select/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->