### PR TITLE
fix: Keep multiple select open on clear

### DIFF
--- a/src/SelectInput/index.tsx
+++ b/src/SelectInput/index.tsx
@@ -200,8 +200,8 @@ export default React.forwardRef<SelectInputRef, SelectInputProps>(function Selec
         if (!shouldPreventClose) {
           toggleOpen();
         }
-      } else if (triggerOpen) {
-        // Lazy should also close when click clear icon
+      } else if (triggerOpen && !multiple) {
+        // Lazy should also close when click clear icon in single select.
         toggleOpen(false);
       }
     }

--- a/tests/Multiple.test.tsx
+++ b/tests/Multiple.test.tsx
@@ -108,6 +108,27 @@ describe('Select.Multiple', () => {
     expect(container.querySelector('input').value).toBe('');
   });
 
+  it('keeps popup open when clearing values', () => {
+    const onPopupVisibleChange = jest.fn();
+    const { container } = render(
+      <Select
+        mode="multiple"
+        defaultOpen
+        defaultValue={['1', '2']}
+        allowClear
+        onPopupVisibleChange={onPopupVisibleChange}
+      >
+        <Option value="1">One</Option>
+        <Option value="2">Two</Option>
+      </Select>,
+    );
+
+    fireEvent.mouseDown(container.querySelector('.rc-select-clear'));
+
+    expectOpen(container, true);
+    expect(onPopupVisibleChange).not.toHaveBeenCalledWith(false);
+  });
+
   it('tokenize input when mode=tags and open=false', () => {
     const handleChange = jest.fn();
     const handleSelect = jest.fn();


### PR DESCRIPTION
## 变更内容

- 调整 clear icon 的鼠标按下处理：多选模式下点击清空不再触发关闭弹层。
- 补充多选模式回归测试，覆盖 `defaultOpen + allowClear` 清空后弹层保持展开的场景。

## 问题原因

clear icon 会标记 `_select_lazy`，此前内部逻辑在弹层已展开时会统一关闭弹层；这对单选仍然合理，但会打断多选用户清空后继续选择的连续操作。

## 影响

- `multiple` / `tags` 清空后保持当前展开状态。
- 非多选清空时仍保留原有关闭行为。

## 验证

- `npm test -- tests/Multiple.test.tsx tests/Select.test.tsx --runInBand --silent`
- `npm run tsc`

关联 ant-design/ant-design#58336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了多选选择框使用清除按钮时下拉菜单意外关闭的问题。

* **Tests**
  * 新增测试用例验证多选模式下清除值后下拉菜单保持打开状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->