### PR TITLE
fix: preserve min width for numeric popup width

### DIFF
--- a/src/SelectTrigger.tsx
+++ b/src/SelectTrigger.tsx
@@ -137,11 +137,7 @@ const SelectTrigger: React.ForwardRefRenderFunction<RefTriggerProps, SelectTrigg
   const isNumberPopupWidth = typeof popupMatchSelectWidth === 'number';
 
   const stretch = React.useMemo(() => {
-    if (isNumberPopupWidth) {
-      return null;
-    }
-
-    return popupMatchSelectWidth === false ? 'minWidth' : 'width';
+    return popupMatchSelectWidth === false || isNumberPopupWidth ? 'minWidth' : 'width';
   }, [popupMatchSelectWidth, isNumberPopupWidth]);
 
   let mergedPopupStyle = popupStyle;

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1737,6 +1737,22 @@ describe('Select.Basic', () => {
       expect(container.querySelectorAll('.rc-select-item')).toHaveLength(options.length);
     });
 
+    it('dropdown menu width should not be smaller than trigger when popupMatchSelectWidth is a number', () => {
+      const { container } = render(
+        <Select style={{ width: 1000 }} popupMatchSelectWidth={500}>
+          <Option value={0}>0</Option>
+        </Select>,
+      );
+
+      toggleOpen(container);
+
+      expect(container.querySelector('.rc-select-dropdown')).toHaveStyle({
+        minWidth: '1000px',
+        width: '500px',
+      });
+      expect(global.triggerProps.stretch).toBe('minWidth');
+    });
+
     it('virtual false also no render virtual list', () => {
       const options = [];
       for (let i = 0; i < 99; i += 1) {


### PR DESCRIPTION
### 背景

`popupMatchSelectWidth` 传入 number 时，历史行为和文档语义都是下拉框宽度不应小于触发器宽度，即实际宽度应为 `max(popupMatchSelectWidth, triggerWidth)`。

在使用 `@rc-component/trigger` 的 `stretch` 逻辑后，number 场景会跳过 stretch，只保留 `width: popupMatchSelectWidth`，导致当传入值小于选择器宽度时，下拉框会被固定成更窄的宽度。

### 修改

- number 场景下将 `stretch` 设置为 `minWidth`，让 trigger 继续补充触发器宽度作为最小宽度。
- 保留现有 `width: popupMatchSelectWidth`，因此传入值大于触发器宽度时仍按自定义宽度展示。
- 增加测试覆盖 `popupMatchSelectWidth` 为 number 且小于触发器宽度的场景。

### 验证

- `npm test -- tests/Select.test.tsx`
- `npm test -- tests/Select.test.tsx -t "dropdownMatchSelectWidth"`
- `npm run tsc`
- `npm run lint`（仅存在既有 warning，无 error）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了下拉触发宽度在传入数字配置时的计算行为，使其与“最小宽度”逻辑保持一致。
  * 优化了下拉菜单在不同宽度配置下的展示效果，避免出现宽度表现不一致的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->