### PR TITLE
fix: avoid selecting active option when Enter confirms IME composition

### DIFF
--- a/src/BaseSelect/index.tsx
+++ b/src/BaseSelect/index.tsx
@@ -490,6 +490,10 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
 
     const isEnterKey = key === 'Enter';
 
+    // The Enter key that confirms an IME composition should not select the active
+    // option, the same way the Selector skips the tags-mode submit while composing.
+    const isComposingEnter = isEnterKey && event.nativeEvent.isComposing;
+
     if (isEnterKey) {
       // Do not submit form when type in the input
       if (mode !== 'combobox') {
@@ -533,7 +537,7 @@ const BaseSelect = React.forwardRef<BaseSelectRef, BaseSelectProps>((props, ref)
       }
     }
 
-    if (mergedOpen && (!isEnterKey || !keyLockRef.current)) {
+    if (mergedOpen && (!isEnterKey || !keyLockRef.current) && !isComposingEnter) {
       // Lock the Enter key after it is pressed to avoid repeated triggering of the onChange event.
       if (isEnterKey) {
         keyLockRef.current = true;

--- a/tests/Composition.test.tsx
+++ b/tests/Composition.test.tsx
@@ -1,0 +1,50 @@
+import { createEvent, fireEvent, render } from '@testing-library/react';
+import KeyCode from 'rc-util/lib/KeyCode';
+import { act } from 'react';
+import Select, { Option } from '../src';
+import { keyDown } from './utils/common';
+
+// The keydown that confirms an IME composition still reports `which === ENTER`
+// on some browsers (e.g. Safari) while `isComposing` is true.
+function imeEnterKeyDown(element: HTMLElement) {
+  const event = createEvent.keyDown(element, { keyCode: KeyCode.ENTER });
+  Object.defineProperties(event, {
+    which: { get: () => KeyCode.ENTER },
+    isComposing: { get: () => true },
+  });
+  act(() => {
+    fireEvent(element, event);
+  });
+}
+
+describe('Select.Composition', () => {
+  it('does not select the active option when Enter only confirms the IME composition', () => {
+    const onChange = jest.fn();
+    const onSelect = jest.fn();
+    const { container } = render(
+      <Select showSearch open onChange={onChange} onSelect={onSelect}>
+        <Option value="1">One</Option>
+        <Option value="2">Two</Option>
+      </Select>,
+    );
+
+    imeEnterKeyDown(container.querySelector('input'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('still selects the active option on a normal Enter', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Select showSearch open onChange={onChange}>
+        <Option value="1">One</Option>
+        <Option value="2">Two</Option>
+      </Select>,
+    );
+
+    keyDown(container.querySelector('input'), KeyCode.ENTER);
+
+    expect(onChange).toHaveBeenCalledWith('1', expect.anything());
+  });
+});


### PR DESCRIPTION
When the dropdown is open in a searchable Select, the keydown handler in `BaseSelect` forwards Enter to the option list and selects the active option whenever `key === 'Enter'`, without checking whether that Enter is confirming an IME composition.

So when a user types CJK text (Japanese/Chinese/Korean), the first option is highlighted by `defaultActiveFirstOption`, and the Enter the user presses to confirm the IME conversion selects that highlighted option before they have finished composing. `Selector` already guards this for the tags-mode submit with `!compositionStatusRef.current`, but the option-selection path in `BaseSelect` was missing the equivalent check.

This shows up on browsers where the Enter that confirms the composition still reports `keyCode === 13`, the same case the `Selector` already handles for tags mode. In Chrome the option list's `which` switch misses it (keyCode is `229` there), but `isComposing` is set in every browser, so it is the reliable thing to check.

Fix: skip the option-list keydown when the Enter is confirming a composition (`event.nativeEvent.isComposing`).

Added `tests/Composition.test.tsx`: a composing Enter no longer fires `onChange`/`onSelect`, while a normal Enter still selects the active option. Full suite stays green.
