### PR TITLE
Fix placeholder visibility inheritance

### DIFF
--- a/src/SelectInput/Content/Placeholder.tsx
+++ b/src/SelectInput/Content/Placeholder.tsx
@@ -20,7 +20,7 @@ export default function Placeholder(props: PlaceholderProps) {
     <div
       className={clsx(`${prefixCls}-placeholder`, classNames?.placeholder)}
       style={{
-        visibility: show ? 'visible' : 'hidden',
+        ...(show ? {} : { visibility: 'hidden' }),
         ...styles?.placeholder,
       }}
     >

--- a/tests/__snapshots__/Combobox.test.tsx.snap
+++ b/tests/__snapshots__/Combobox.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`Select.Combobox renders controlled correctly 1`] = `
   >
     <div
       class="rc-select-placeholder"
-      style="visibility: visible;"
     >
       Search
     </div>
@@ -37,7 +36,6 @@ exports[`Select.Combobox renders correctly 1`] = `
   >
     <div
       class="rc-select-placeholder"
-      style="visibility: visible;"
     >
       Search
     </div>

--- a/tests/__snapshots__/ssr.test.tsx.snap
+++ b/tests/__snapshots__/ssr.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Select.SSR should work 1`] = `"<div class="rc-select rc-select-single"><div class="rc-select-content"><div class="rc-select-placeholder" style="visibility:visible"></div><input id="test-id" type="text" readonly="" autoComplete="new-password" class="rc-select-input" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list" value=""/></div></div>"`;
+exports[`Select.SSR should work 1`] = `"<div class="rc-select rc-select-single"><div class="rc-select-content"><div class="rc-select-placeholder"></div><input id="test-id" type="text" readonly="" autoComplete="new-password" class="rc-select-input" role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list" value=""/></div></div>"`;

--- a/tests/placeholder.test.tsx
+++ b/tests/placeholder.test.tsx
@@ -15,6 +15,19 @@ describe('Select placeholder', () => {
     });
   });
 
+  it('should not force placeholder visible when select is hidden', () => {
+    const { container } = render(<Select style={{ visibility: 'hidden' }} placeholder="bamboo" />);
+    const placeholder = container.querySelector<HTMLElement>('.rc-select-placeholder')!;
+
+    expect(container.querySelector('.rc-select')).toHaveStyle({
+      visibility: 'hidden',
+    });
+    expect(placeholder).not.toHaveAttribute(
+      'style',
+      expect.stringContaining('visibility: visible'),
+    );
+  });
+
   it('when value is null', () => {
     const { container } = render(<Select value={null} placeholder="bamboo" />);
     expect(container.querySelector('.rc-select-placeholder')).toBeTruthy();


### PR DESCRIPTION
## 变更内容

- 移除 placeholder 默认写入的 `visibility: visible`，让其继承父级 `visibility`。
- 保留 placeholder 需要隐藏时的 `visibility: hidden` 行为。
- 新增父级 `visibility: hidden` 的回归测试，并更新相关快照。

## 修复原因

关联 ant-design/ant-design#58567。TreeSelect/Select 外层设置 `visibility: hidden` 时，placeholder 内联 `visibility: visible` 会覆盖父级隐藏状态，导致 placeholder 仍可见。

## 验证

- `npm test` 通过（21 suites / 428 tests）
- `npm run lint -- --quiet` 通过
- `git diff --check` 通过
- `npm run tsc` 未通过：本地 `node_modules` 缺少 package.json 中声明的 devDependency `@rc-component/dialog`，报错位置是 `docs/examples/getPopupContainer.tsx`，与本次改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了占位符的样式处理，避免在某些隐藏场景下强制显示占位内容。
  * 当选择器本身设置为隐藏时，占位符会保持正确的可见性表现，不再覆盖外层样式。
* **Tests**
  * 新增相关测试，覆盖选择器隐藏时占位符的显示行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->