### PR TITLE
fix: set option list virtual prefix

### DIFF
--- a/src/OptionList.tsx
+++ b/src/OptionList.tsx
@@ -323,6 +323,7 @@ const OptionList: React.ForwardRefRenderFunction<RefOptionListProps, {}> = (_, r
         </div>
       )}
       <List<FlattenOptionData<BaseOptionType>>
+        prefixCls={`${prefixCls}-dropdown-list`}
         itemKey="key"
         ref={listRef}
         data={memoFlattenOptions}

--- a/tests/Accessibility.test.tsx
+++ b/tests/Accessibility.test.tsx
@@ -193,7 +193,7 @@ describe('Select.Accessibility', () => {
         }
       });
 
-      const rcVirtual = document.querySelector('.rc-virtual-list-holder-inner');
+      const rcVirtual = document.querySelector('.rc-select-dropdown-list-holder-inner');
       expect(rcVirtual).not.toHaveAttribute('role');
       const rcOptionItem = rcVirtual.querySelectorAll('.rc-select-item-option');
 

--- a/tests/OptionList.test.tsx
+++ b/tests/OptionList.test.tsx
@@ -560,7 +560,9 @@ describe('OptionList', () => {
       const { container } = render(<Select open showScrollBar options={options} />);
 
       await waitFor(() => {
-        const scrollbarElement = container.querySelector('.rc-virtual-list-scrollbar-visible');
+        const scrollbarElement = container.querySelector(
+          '.rc-select-dropdown-list-scrollbar-visible',
+        );
         expect(scrollbarElement).not.toBeNull();
       });
     });
@@ -573,7 +575,9 @@ describe('OptionList', () => {
       const { container } = render(<Select open showScrollBar={false} options={options} />);
 
       await waitFor(() => {
-        const scrollbarElement = container.querySelector('.rc-virtual-list-scrollbar-visible');
+        const scrollbarElement = container.querySelector(
+          '.rc-select-dropdown-list-scrollbar-visible',
+        );
         expect(scrollbarElement).toBeNull();
       });
     });

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -180,9 +180,9 @@ describe('Select.Basic', () => {
       );
 
       // these generate the same snapshots
-      expect(containerFirst.querySelector('.rc-virtual-list')).toMatchSnapshot();
-      expect(containerSecond.querySelector('.rc-virtual-list')).toMatchSnapshot();
-      expect(containerThird.querySelector('.rc-virtual-list')).toMatchSnapshot();
+      expect(containerFirst.querySelector('.rc-select-dropdown-list')).toMatchSnapshot();
+      expect(containerSecond.querySelector('.rc-select-dropdown-list')).toMatchSnapshot();
+      expect(containerThird.querySelector('.rc-select-dropdown-list')).toMatchSnapshot();
     });
   });
 
@@ -2619,7 +2619,7 @@ describe('Select.Basic', () => {
     const options = new Array(10).fill(null).map((_, value) => ({ value }));
 
     const { container } = testingRender(<Select open direction="rtl" options={options} />);
-    expect(container.querySelector('.rc-virtual-list-rtl')).toBeTruthy();
+    expect(container.querySelector('.rc-select-dropdown-list-rtl')).toBeTruthy();
   });
 
   it('Should optionRender work', () => {
@@ -2720,7 +2720,7 @@ describe('Select.Basic', () => {
       />,
     );
     const element = container.querySelectorAll<HTMLDivElement>(
-      'div.rc-virtual-list-holder-inner .rc-select-item',
+      'div.rc-select-dropdown-list-holder-inner .rc-select-item',
     );
     expect(element[0]).not.toHaveClass('rc-select-item-option-disabled');
     expect(element[1]).toHaveClass('rc-select-item-option-disabled');
@@ -2811,7 +2811,7 @@ describe('Select.Basic', () => {
     const prefix = container.querySelector('.rc-select-prefix');
     const suffix = container.querySelector('.rc-select-suffix');
     const item = container.querySelector('.rc-select-item-option');
-    const list = container.querySelector('.rc-virtual-list');
+    const list = container.querySelector('.rc-select-dropdown-list');
     const input = container.querySelector('input');
     expect(prefix).toHaveClass(customClassNames.prefix);
     expect(prefix).toHaveStyle(customStyle.prefix);

--- a/tests/__snapshots__/OptionList.test.tsx.snap
+++ b/tests/__snapshots__/OptionList.test.tsx.snap
@@ -27,15 +27,15 @@ exports[`OptionList renders correctly virtual 1`] = `
     />
   </div>
   <div
-    class="rc-virtual-list"
+    class="rc-select-dropdown-list"
     style="position: relative;"
   >
     <div
-      class="rc-virtual-list-holder"
+      class="rc-select-dropdown-list-holder"
     >
       <div>
         <div
-          class="rc-virtual-list-holder-inner"
+          class="rc-select-dropdown-list-holder-inner"
           style="display: flex; flex-direction: column;"
         >
           <div
@@ -102,15 +102,15 @@ exports[`OptionList renders correctly virtual 1`] = `
 exports[`OptionList renders correctly without virtual 1`] = `
 <div>
   <div
-    class="rc-virtual-list"
+    class="rc-select-dropdown-list"
     style="position: relative;"
   >
     <div
-      class="rc-virtual-list-holder"
+      class="rc-select-dropdown-list-holder"
     >
       <div>
         <div
-          class="rc-virtual-list-holder-inner"
+          class="rc-select-dropdown-list-holder-inner"
           id="undefined_list"
           role="listbox"
           style="display: flex; flex-direction: column;"

--- a/tests/__snapshots__/Select.test.tsx.snap
+++ b/tests/__snapshots__/Select.test.tsx.snap
@@ -29,16 +29,16 @@ exports[`Select.Basic does not filter when filterOption value is false 1`] = `
       </div>
     </div>
     <div
-      class="rc-virtual-list"
+      class="rc-select-dropdown-list"
       style="position: relative;"
     >
       <div
-        class="rc-virtual-list-holder"
+        class="rc-select-dropdown-list-holder"
         style="max-height: 200px; overflow-y: auto;"
       >
         <div>
           <div
-            class="rc-virtual-list-holder-inner"
+            class="rc-select-dropdown-list-holder-inner"
             style="display: flex; flex-direction: column;"
           >
             <div
@@ -265,16 +265,16 @@ exports[`Select.Basic render renders role prop correctly 1`] = `
 
 exports[`Select.Basic render should support fieldName 1`] = `
 <div
-  class="rc-virtual-list"
+  class="rc-select-dropdown-list"
   style="position: relative;"
 >
   <div
-    class="rc-virtual-list-holder"
+    class="rc-select-dropdown-list-holder"
     style="max-height: 200px; overflow-y: auto;"
   >
     <div>
       <div
-        class="rc-virtual-list-holder-inner"
+        class="rc-select-dropdown-list-holder-inner"
         style="display: flex; flex-direction: column;"
       >
         <div
@@ -312,16 +312,16 @@ exports[`Select.Basic render should support fieldName 1`] = `
 
 exports[`Select.Basic render should support fieldName 2`] = `
 <div
-  class="rc-virtual-list"
+  class="rc-select-dropdown-list"
   style="position: relative;"
 >
   <div
-    class="rc-virtual-list-holder"
+    class="rc-select-dropdown-list-holder"
     style="max-height: 200px; overflow-y: auto;"
   >
     <div>
       <div
-        class="rc-virtual-list-holder-inner"
+        class="rc-select-dropdown-list-holder-inner"
         style="display: flex; flex-direction: column;"
       >
         <div
@@ -359,16 +359,16 @@ exports[`Select.Basic render should support fieldName 2`] = `
 
 exports[`Select.Basic render should support fieldName 3`] = `
 <div
-  class="rc-virtual-list"
+  class="rc-select-dropdown-list"
   style="position: relative;"
 >
   <div
-    class="rc-virtual-list-holder"
+    class="rc-select-dropdown-list-holder"
     style="max-height: 200px; overflow-y: auto;"
   >
     <div>
       <div
-        class="rc-virtual-list-holder-inner"
+        class="rc-select-dropdown-list-holder-inner"
         style="display: flex; flex-direction: column;"
       >
         <div
@@ -433,16 +433,16 @@ exports[`Select.Basic should contain falsy children 1`] = `
       </div>
     </div>
     <div
-      class="rc-virtual-list"
+      class="rc-select-dropdown-list"
       style="position: relative;"
     >
       <div
-        class="rc-virtual-list-holder"
+        class="rc-select-dropdown-list-holder"
         style="max-height: 200px; overflow-y: auto;"
       >
         <div>
           <div
-            class="rc-virtual-list-holder-inner"
+            class="rc-select-dropdown-list-holder-inner"
             style="display: flex; flex-direction: column;"
           >
             <div
@@ -532,16 +532,16 @@ exports[`Select.Basic should render custom dropdown correctly 1`] = `
         </div>
       </div>
       <div
-        class="rc-virtual-list"
+        class="rc-select-dropdown-list"
         style="position: relative;"
       >
         <div
-          class="rc-virtual-list-holder"
+          class="rc-select-dropdown-list-holder"
           style="max-height: 200px; overflow-y: auto;"
         >
           <div>
             <div
-              class="rc-virtual-list-holder-inner"
+              class="rc-select-dropdown-list-holder-inner"
               style="display: flex; flex-direction: column;"
             >
               <div

--- a/tests/__snapshots__/Tags.test.tsx.snap
+++ b/tests/__snapshots__/Tags.test.tsx.snap
@@ -106,16 +106,16 @@ exports[`Select.Tags OptGroup renders correctly 1`] = `
         />
       </div>
       <div
-        class="rc-virtual-list"
+        class="rc-select-dropdown-list"
         style="position: relative;"
       >
         <div
-          class="rc-virtual-list-holder"
+          class="rc-select-dropdown-list-holder"
           style="max-height: 200px; overflow-y: auto;"
         >
           <div>
             <div
-              class="rc-virtual-list-holder-inner"
+              class="rc-select-dropdown-list-holder-inner"
               style="display: flex; flex-direction: column;"
             >
               <div


### PR DESCRIPTION
### 这个改动解决什么？

为 Select 的 OptionList 中的 VirtualList 设置 `prefixCls={`${prefixCls}-dropdown-list`}`，使下拉虚拟列表及滚动条生成 Select 自身前缀类名，例如 `rc-select-dropdown-list-scrollbar`，便于上层组件按 Select 语义样式精确覆盖。

### 具体改动

- 为 OptionList 的 VirtualList 传入 dropdown list prefixCls
- 更新相关测试断言与快照

### 验证

- `npm test -- tests/OptionList.test.tsx tests/Select.test.tsx tests/Accessibility.test.tsx tests/Tags.test.tsx --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式与可访问性**
  - 优化虚拟下拉列表的样式标识，提升列表与滚动条状态的区分度。
  - 保持虚拟列表的 ARIA 属性行为不变，确保辅助功能支持一致。

- **测试**
  - 更新下拉列表、滚动条、RTL 模式及多选场景的相关验证，确保新样式标识和交互行为正常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->